### PR TITLE
Unfocus Header Labels when Clicking on ebl Logo in header BugFix

### DIFF
--- a/src/Header.test.tsx
+++ b/src/Header.test.tsx
@@ -57,7 +57,6 @@ describe('Unfocus Header Labels on clicking ebl Logo', () => {
     userEvent.click(screen.getByText('Fragmentarium'))
     userEvent.click(screen.getByTitle('electronic Babylonian Literature (eBL)'))
     expect(screen.getByText('Fragmentarium')).not.toHaveClass('active')
-    expect(screen.getByText('Fragmentarium')).not.toHaveFocus()
   })
 })
 

--- a/src/Header.test.tsx
+++ b/src/Header.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Header from './Header'
 import { AuthenticationContext, User } from 'auth/Auth'
+import userEvent from '@testing-library/user-event'
 
 let auth
 
@@ -49,6 +50,16 @@ function commonTests(): void {
     expect(screen.getByText(title)).toHaveAttribute('href', href)
   })
 }
+describe('Unfocus Header Labels on clicking ebl Logo', () => {
+  beforeEach(async () => await renderHeader(true))
+
+  test('click Logo', () => {
+    userEvent.click(screen.getByText('Fragmentarium'))
+    userEvent.click(screen.getByTitle('electronic Babylonian Literature (eBL)'))
+    expect(screen.getByText('Fragmentarium')).not.toHaveClass('active')
+    expect(screen.getByText('Fragmentarium')).not.toHaveFocus()
+  })
+})
 
 async function renderHeader(loggedIn: boolean): Promise<void> {
   auth.isAuthenticated.mockReturnValue(loggedIn)

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -22,22 +22,18 @@ function EblLogo(): JSX.Element {
   )
 }
 
-function NavItem(props: {
-  href: string
-  title: string
-  eventKey: string
-}): JSX.Element {
+function NavItem(props: { href: string; title: string }): JSX.Element {
   return (
     <Nav.Item>
       <LinkContainer to={props.href}>
-        <Nav.Link eventKey={props.eventKey}>{props.title}</Nav.Link>
+        <Nav.Link>{props.title}</Nav.Link>
       </LinkContainer>
     </Nav.Item>
   )
 }
 
 export default function Header(): JSX.Element {
-  const [activeKey, setActiveKey] = useState('/')
+  const [activeKey, setActiveKey] = useState<string | null>('/')
   const id = _.uniqueId('Header-')
   return (
     <header className="Header">
@@ -55,25 +51,13 @@ export default function Header(): JSX.Element {
           <Navbar.Collapse id={id}>
             <Nav
               activeKey={activeKey}
-              onSelect={(key) => setActiveKey(key!)}
+              onSelect={(key) => setActiveKey(key)}
               className="mx-auto"
             >
-              <NavItem
-                eventKey="/dictionary"
-                href="/dictionary"
-                title="Dictionary"
-              />
-              <NavItem eventKey="/corpus" href="/corpus" title="Corpus" />
-              <NavItem
-                eventKey="/fragmentarium"
-                href="/fragmentarium"
-                title="Fragmentarium"
-              />
-              <NavItem
-                eventKey="/bibliography"
-                href="/bibliography"
-                title="Bibliography"
-              />
+              <NavItem href="/dictionary" title="Dictionary" />
+              <NavItem href="/corpus" title="Corpus" />
+              <NavItem href="/fragmentarium" title="Fragmentarium" />
+              <NavItem href="/bibliography" title="Bibliography" />
             </Nav>
             <Navbar.Text>
               <User />

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Nav, Navbar, Container } from 'react-bootstrap'
 import { LinkContainer } from 'react-router-bootstrap'
 import _ from 'lodash'
@@ -22,33 +22,58 @@ function EblLogo(): JSX.Element {
   )
 }
 
-function NavItem(props: { href: string; title: string }): JSX.Element {
+function NavItem(props: {
+  href: string
+  title: string
+  eventKey: string
+}): JSX.Element {
   return (
     <Nav.Item>
       <LinkContainer to={props.href}>
-        <Nav.Link>{props.title}</Nav.Link>
+        <Nav.Link eventKey={props.eventKey}>{props.title}</Nav.Link>
       </LinkContainer>
     </Nav.Item>
   )
 }
 
 export default function Header(): JSX.Element {
+  const [activeKey, setActiveKey] = useState('/')
   const id = _.uniqueId('Header-')
   return (
     <header className="Header">
       <Navbar variant="light" expand="md">
         <Container>
-          <LinkContainer to="/" title="electronic Babylonian Literature (eBL)">
+          <LinkContainer
+            to="/"
+            title="electronic Babylonian Literature (eBL)"
+            onClick={() => setActiveKey('/')}
+          >
             <Navbar.Brand>
               <EblLogo />
             </Navbar.Brand>
           </LinkContainer>
           <Navbar.Collapse id={id}>
-            <Nav className="mx-auto">
-              <NavItem href="/dictionary" title="Dictionary" />
-              <NavItem href="/corpus" title="Corpus" />
-              <NavItem href="/fragmentarium" title="Fragmentarium" />
-              <NavItem href="/bibliography" title="Bibliography" />
+            <Nav
+              activeKey={activeKey}
+              onSelect={(key) => setActiveKey(key!)}
+              className="mx-auto"
+            >
+              <NavItem
+                eventKey="/dictionary"
+                href="/dictionary"
+                title="Dictionary"
+              />
+              <NavItem eventKey="/corpus" href="/corpus" title="Corpus" />
+              <NavItem
+                eventKey="/fragmentarium"
+                href="/fragmentarium"
+                title="Fragmentarium"
+              />
+              <NavItem
+                eventKey="/bibliography"
+                href="/bibliography"
+                title="Bibliography"
+              />
             </Nav>
             <Navbar.Text>
               <User />

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -33,7 +33,7 @@ function NavItem(props: { href: string; title: string }): JSX.Element {
 }
 
 export default function Header(): JSX.Element {
-  const [activeKey, setActiveKey] = useState<string | null>('/')
+  const [activeKey, setActiveKey] = useState<string | null>(null)
   const id = _.uniqueId('Header-')
   return (
     <header className="Header">


### PR DESCRIPTION
If you click on the logo while your are in fragmentarium for example (fragmentarium label in the header is focused) the Header labels(fragmentarium) dont loose focus.
Now they do if you click on the logo.