### PR TITLE
Fragment display tweaks

### DIFF
--- a/src/fragmentarium/ui/display/Display.tsx
+++ b/src/fragmentarium/ui/display/Display.tsx
@@ -36,7 +36,7 @@ function createParagraphs(
 
 function FragmentIntroduction({ parts }: { parts: readonly MarkupPart[] }) {
   return (
-    <section className="Introduction">
+    <section className="CuneiformFragment__introduction">
       <h4>Introduction</h4>
       {createParagraphs(parts).map((paragraphParts, index) => (
         <Markup parts={paragraphParts} key={index} container={'p'} />

--- a/src/fragmentarium/ui/display/Display.tsx
+++ b/src/fragmentarium/ui/display/Display.tsx
@@ -52,7 +52,7 @@ function Display({ fragment, wordService, activeLine }: Props): JSX.Element {
         <FragmentIntroduction parts={fragment.introduction.parts} />
       )}
       <Transliteration text={fragment.text} activeLine={activeLine} />
-      {fragment.notes && <Notes fragment={fragment} />}
+      {fragment.notes.trim() && <Notes fragment={fragment} />}
       <Glossary text={fragment.text} wordService={wordService} />
     </>
   )

--- a/src/fragmentarium/ui/display/__snapshots__/Display.test.tsx.snap
+++ b/src/fragmentarium/ui/display/__snapshots__/Display.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Snapshot 1`] = `
 <div>
   <section
-    class="Introduction"
+    class="CuneiformFragment__introduction"
   >
     <h4>
       Introduction

--- a/src/fragmentarium/ui/fragment/CuneiformFragment.sass
+++ b/src/fragmentarium/ui/fragment/CuneiformFragment.sass
@@ -8,3 +8,6 @@
 
     section
       padding-bottom: 1rem
+  
+  &__introduction
+    text-align: justify

--- a/src/transliteration/ui/Glossary.tsx
+++ b/src/transliteration/ui/Glossary.tsx
@@ -10,9 +10,12 @@ import {
 
 import './Glossary.sass'
 import GlossaryFactory from 'transliteration/application/GlossaryFactory'
+import _ from 'lodash'
 
 export function Glossary({ data }: { data: GlossaryData }): JSX.Element {
-  return (
+  return _.isEmpty(data) ? (
+    <></>
+  ) : (
     <section>
       <h4>Glossary</h4>
       {[...data].sort(compareGlossaryEntries).map(([lemma, tokensByLemma]) => (

--- a/src/transliteration/ui/__snapshots__/markup.test.tsx.snap
+++ b/src/transliteration/ui/__snapshots__/markup.test.tsx.snap
@@ -33,6 +33,8 @@ exports[`Markup 1`] = `
     </span>
     <a
       href="https://www.ebl.lmu.de/"
+      rel="noopener noreferrer"
+      target="_blank"
     >
       link to eBL
     </a>

--- a/src/transliteration/ui/markup.tsx
+++ b/src/transliteration/ui/markup.tsx
@@ -31,7 +31,11 @@ export function DisplayUrlPart({
 }: {
   part: UrlPart
 }): JSX.Element {
-  return <a href={url}>{text}</a>
+  return (
+    <a href={url} target="_blank" rel="noopener noreferrer">
+      {text || url}
+    </a>
+  )
 }
 
 export function DisplayLaguagePart({


### PR DESCRIPTION
- Hide eBL notes if they contain only whitespace
- Hide the Glossary section if it's empty
- Justify Fragment Introduction text