### PR TITLE
Add Fragmentarium search tab hash and fix chapter line links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -241,6 +241,7 @@ function App({
                   fragmentQuery={parseFragmentSearchParams(location)}
                   wordService={wordService}
                   textService={textService}
+                  activeTab={_.trimStart(location.hash, '#')}
                 />
               )}
             />

--- a/src/corpus/ui/LineNumber.test.tsx
+++ b/src/corpus/ui/LineNumber.test.tsx
@@ -52,6 +52,11 @@ test('Clicking on line number sets anchor', () => {
   userEvent.click(screen.getByText(lineNumberString))
   expect(global.window.location.hash).toEqual(`#${lineNumberString}`)
 })
+test('Clicking on line number scrolls to line', () => {
+  renderLineNumber()
+  userEvent.click(screen.getByText(lineNumberString))
+  expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalled()
+})
 test('Line number with url points to link', () => {
   const externalUrl = 'https://ebl.lmu.de/an-external-link'
   renderLineNumber(externalUrl)

--- a/src/corpus/ui/LineNumber.test.tsx
+++ b/src/corpus/ui/LineNumber.test.tsx
@@ -25,7 +25,7 @@ const lineDisplay = lineDisplayFactory.build(
 )
 const lineNumberString = lineNumberToString(lineDisplay.number)
 
-function renderLineNumber(): void {
+function renderLineNumber(url = ''): void {
   render(
     <table>
       <tbody>
@@ -34,6 +34,7 @@ function renderLineNumber(): void {
             line={lineDisplay}
             activeLine={''}
             showOldLineNumbers={true}
+            url={url}
           />
         </tr>
       </tbody>
@@ -50,4 +51,12 @@ test('Clicking on line number sets anchor', () => {
   renderLineNumber()
   userEvent.click(screen.getByText(lineNumberString))
   expect(global.window.location.hash).toEqual(`#${lineNumberString}`)
+})
+test('Line number with url points to link', () => {
+  const externalUrl = 'https://ebl.lmu.de/an-external-link'
+  renderLineNumber(externalUrl)
+  expect(screen.getByText(lineNumberString)).toHaveAttribute(
+    'href',
+    `${externalUrl}#${lineNumberString}`
+  )
 })

--- a/src/corpus/ui/LineNumber.test.tsx
+++ b/src/corpus/ui/LineNumber.test.tsx
@@ -4,6 +4,9 @@ import { lineDisplayFactory } from 'test-support/chapter-fixtures'
 import lineNumberToString from 'transliteration/domain/lineNumberToString'
 import LineNumber from './LineNumber'
 import { oldLineNumberFactory } from 'test-support/linenumber-factory'
+import userEvent from '@testing-library/user-event'
+
+window.HTMLElement.prototype.scrollIntoView = jest.fn()
 
 const LINE_NUMBER = '76a'
 
@@ -20,13 +23,31 @@ const lineDisplay = lineDisplayFactory.build(
     },
   }
 )
+const lineNumberString = lineNumberToString(lineDisplay.number)
+
+function renderLineNumber(): void {
+  render(
+    <table>
+      <tbody>
+        <tr>
+          <LineNumber
+            line={lineDisplay}
+            activeLine={''}
+            showOldLineNumbers={true}
+          />
+        </tr>
+      </tbody>
+    </table>
+  )
+}
 
 test('LineNumber', () => {
-  render(
-    <LineNumber line={lineDisplay} activeLine={''} showOldLineNumbers={true} />
-  )
-  expect(
-    screen.getByText(`${lineNumberToString(lineDisplay.number)}`)
-  ).toBeVisible()
+  renderLineNumber()
+  expect(screen.getByText(lineNumberString)).toBeVisible()
   expect(screen.getByText(LINE_NUMBER)).toBeVisible()
+})
+test('Clicking on line number sets anchor', () => {
+  renderLineNumber()
+  userEvent.click(screen.getByText(lineNumberString))
+  expect(global.window.location.hash).toEqual(`#${lineNumberString}`)
 })

--- a/src/corpus/ui/LineNumber.tsx
+++ b/src/corpus/ui/LineNumber.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef } from 'react'
 import lineNumberToString, {
   lineNumberToAtf,
 } from 'transliteration/domain/lineNumberToString'
-import { Anchor } from 'transliteration/ui/line-number'
 import { OldLineNumber } from 'transliteration/domain/line-number'
 import referencePopover from 'bibliography/ui/referencePopover'
 import classnames from 'classnames'
@@ -53,6 +52,7 @@ export default function LineNumber({
 }): JSX.Element {
   const ref = useRef<HTMLAnchorElement>(null)
   const id = lineNumberToAtf(line.number)
+  const hash = `#${encodeURIComponent(id)}`
 
   useEffect(() => {
     if (id === activeLine) {
@@ -68,17 +68,23 @@ export default function LineNumber({
       })}
     >
       {url ? (
-        <a
-          href={`${url}#${encodeURIComponent(id)}`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a href={`${url}${hash}`} target="_blank" rel="noopener noreferrer">
           {lineNumberToString(line.number)}
         </a>
       ) : (
-        <Anchor className="chapter-display__anchor" id={id} ref={ref}>
+        <a
+          className="chapter-display__anchor"
+          id={id}
+          ref={ref}
+          href={hash}
+          onClick={(event) => {
+            event.preventDefault()
+            window.history.replaceState(null, '', hash)
+            ref.current?.scrollIntoView({ behavior: 'smooth' })
+          }}
+        >
           {lineNumberToString(line.number)}
-        </Anchor>
+        </a>
       )}
       {!_.isEmpty(line.oldLineNumbers) && (
         <OldLineNumbers

--- a/src/dictionary/ui/display/LemmaQueryLink.tsx
+++ b/src/dictionary/ui/display/LemmaQueryLink.tsx
@@ -12,9 +12,9 @@ export default function LemmaQueryLink({
 }): JSX.Element {
   return (
     <ExternalLink
-      href={`/fragmentarium/search/?lemmas=${encodeURIComponent(
-        lemmaId
-      )}${anchor}`}
+      href={`/fragmentarium/search/?lemmas=${encodeURIComponent(lemmaId)}${
+        anchor || ''
+      }`}
       title={`View in fragmentarium search`}
     >
       {children}

--- a/src/dictionary/ui/display/LemmaQueryLink.tsx
+++ b/src/dictionary/ui/display/LemmaQueryLink.tsx
@@ -4,13 +4,17 @@ import ExternalLink from 'common/ExternalLink'
 export default function LemmaQueryLink({
   lemmaId,
   children,
+  anchor,
 }: {
   lemmaId: string
   children?: React.ReactNode
+  anchor?: string
 }): JSX.Element {
   return (
     <ExternalLink
-      href={`/fragmentarium/search/?lemmas=${encodeURIComponent(lemmaId)}`}
+      href={`/fragmentarium/search/?lemmas=${encodeURIComponent(
+        lemmaId
+      )}${anchor}`}
       title={`View in fragmentarium search`}
     >
       {children}

--- a/src/dictionary/ui/display/__snapshots__/WordDisplay.test.tsx.snap
+++ b/src/dictionary/ui/display/__snapshots__/WordDisplay.test.tsx.snap
@@ -1109,7 +1109,7 @@ exports[`Fetch word correctly displays word parts 1`] = `
         42
          matches 
         <a
-          href="/fragmentarium/search/?lemmas=c49ca1a96f9ce4d45bdc9962307a703eba53c0a8"
+          href="/fragmentarium/search/?lemmas=c49ca1a96f9ce4d45bdc9962307a703eba53c0a8#corpus"
           rel="noopener noreferrer"
           target="_blank"
           title="View in fragmentarium search"
@@ -2120,7 +2120,7 @@ exports[`Fetch word correctly displays word parts 1`] = `
       </div>
       <p>
         <a
-          href="/fragmentarium/search/?lemmas=c49ca1a96f9ce4d45bdc9962307a703eba53c0a8"
+          href="/fragmentarium/search/?lemmas=c49ca1a96f9ce4d45bdc9962307a703eba53c0a8#corpus"
           rel="noopener noreferrer"
           target="_blank"
           title="View in fragmentarium search"

--- a/src/dictionary/ui/search/CorpusLemmaLines.tsx
+++ b/src/dictionary/ui/search/CorpusLemmaLines.tsx
@@ -55,11 +55,11 @@ export default withData<
       <>
         <p>
           {total} matches&nbsp;
-          <LemmaQueryLink lemmaId={lemmaId} />
+          <LemmaQueryLink lemmaId={lemmaId} anchor={'#corpus'} />
         </p>
         <CorpusLines textService={textService} lemmaId={lemmaId} />
         <p>
-          <LemmaQueryLink lemmaId={lemmaId}>
+          <LemmaQueryLink lemmaId={lemmaId} anchor={'#corpus'}>
             Show all {total} matches in Corpus search&nbsp;
           </LemmaQueryLink>
         </p>

--- a/src/fragmentarium/ui/search/FragmentariumSearch.test.tsx
+++ b/src/fragmentarium/ui/search/FragmentariumSearch.test.tsx
@@ -173,8 +173,15 @@ describe('Searching fragments by transliteration', () => {
   it('Displays Fragmentarium result on successful query', async () => {
     expect(container).toHaveTextContent(result.items[1].museumNumber)
   })
-  it('Displays corpus results', async () => {
-    userEvent.click(screen.getByText('Corpus'))
+  it('Displays corpus results when clicking corpus tab', async () => {
+    userEvent.click(screen.getByRole('tab', { name: 'Corpus' }))
     expect(container).toMatchSnapshot()
+  })
+  it('Updates URL anchor when clicking tab', async () => {
+    userEvent.click(screen.getByRole('tab', { name: 'Corpus' }))
+    expect(global.window.location.hash).toEqual('#corpus')
+
+    userEvent.click(screen.getByRole('tab', { name: 'Fragmentarium' }))
+    expect(global.window.location.hash).toEqual('#fragmentarium')
   })
 })

--- a/src/fragmentarium/ui/search/FragmentariumSearch.tsx
+++ b/src/fragmentarium/ui/search/FragmentariumSearch.tsx
@@ -72,11 +72,7 @@ function FragmentariumSearch({
                     eventKey={'fragmentarium'}
                     title={'Fragmentarium'}
                     onEnter={() =>
-                      window.history.replaceState(
-                        null,
-                        'New Page Title',
-                        '#fragmentarium'
-                      )
+                      window.history.replaceState(null, '', '#fragmentarium')
                     }
                   >
                     <SearchResult
@@ -88,11 +84,7 @@ function FragmentariumSearch({
                     eventKey={'corpus'}
                     title={'Corpus'}
                     onEnter={() =>
-                      window.history.replaceState(
-                        null,
-                        'New Page Title',
-                        '#corpus'
-                      )
+                      window.history.replaceState(null, '', '#corpus')
                     }
                   >
                     <CorpusSearchResult

--- a/src/fragmentarium/ui/search/FragmentariumSearch.tsx
+++ b/src/fragmentarium/ui/search/FragmentariumSearch.tsx
@@ -22,6 +22,7 @@ interface Props {
   fragmentQuery: FragmentQuery
   wordService: WordService
   textService: TextService
+  activeTab: string
 }
 
 export const linesToShow = 5
@@ -39,6 +40,7 @@ function FragmentariumSearch({
   fragmentQuery,
   wordService,
   textService,
+  activeTab,
 }: Props): JSX.Element {
   const corpusQuery: CorpusQuery = _.pick(
     fragmentQuery,
@@ -65,14 +67,34 @@ function FragmentariumSearch({
                 />
               </header>
               {showResults ? (
-                <Tabs defaultActiveKey={'fragmentarium'} justify>
-                  <Tab eventKey={'fragmentarium'} title={'Fragmentarium'}>
+                <Tabs defaultActiveKey={activeTab || 'fragmentarium'} justify>
+                  <Tab
+                    eventKey={'fragmentarium'}
+                    title={'Fragmentarium'}
+                    onEnter={() =>
+                      window.history.replaceState(
+                        null,
+                        'New Page Title',
+                        '#fragmentarium'
+                      )
+                    }
+                  >
                     <SearchResult
                       fragmentService={fragmentService}
                       fragmentQuery={fragmentQuery}
                     />
                   </Tab>
-                  <Tab eventKey={'corpus'} title={'Corpus'}>
+                  <Tab
+                    eventKey={'corpus'}
+                    title={'Corpus'}
+                    onEnter={() =>
+                      window.history.replaceState(
+                        null,
+                        'New Page Title',
+                        '#corpus'
+                      )
+                    }
+                  >
                     <CorpusSearchResult
                       textService={textService}
                       corpusQuery={corpusQuery}

--- a/src/fragmentarium/ui/search/__snapshots__/FragmentariumSearch.test.tsx.snap
+++ b/src/fragmentarium/ui/search/__snapshots__/FragmentariumSearch.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Searching fragments by transliteration Displays corpus results 1`] = `
+exports[`Searching fragments by transliteration Displays corpus results when clicking corpus tab 1`] = `
 <div>
   <main
     class="main"


### PR DESCRIPTION
- Adding a `#corpus` anchor to links to the Fragmentarium search now opens the Corpus tab and clicking on the tabs updates the hash to easier share links; if no hash is given, the Fragmentarium tab is opened by default
-  Clicking on line numbers in the Chapter view now updates the url and scrolls to the target line without reloading the page