### PR TITLE
Debug Corpus Search Variant Display

### DIFF
--- a/src/corpus/ui/ChapterView.tsx
+++ b/src/corpus/ui/ChapterView.tsx
@@ -111,7 +111,7 @@ export function ChapterViewTable({
             columns={columns[index]}
             maxColumns={maxColumns_}
             chapter={chapter}
-            lineNumber={index}
+            lineIndex={index}
             textService={textService}
             expandLineLinks={expandLineLinks}
           />

--- a/src/corpus/ui/ChapterView.tsx
+++ b/src/corpus/ui/ChapterView.tsx
@@ -32,8 +32,8 @@ import _ from 'lodash'
 
 interface Props {
   chapter: ChapterDisplay
-  correctedLineNumbers?: readonly number[]
-  correctedVariantNumbers?: readonly number[]
+  lineNumbers?: readonly number[]
+  variantNumbers?: readonly number[]
   expandLineLinks?: boolean
 }
 
@@ -83,8 +83,8 @@ export function ChapterViewTable({
   chapter,
   textService,
   activeLine,
-  correctedLineNumbers,
-  correctedVariantNumbers,
+  lineNumbers,
+  variantNumbers,
   expandLineLinks,
 }: Props & {
   activeLine: string
@@ -106,8 +106,8 @@ export function ChapterViewTable({
             key={index}
             activeLine={activeLine}
             line={line}
-            correctedLineNumber={_.nth(correctedLineNumbers, index)}
-            correctedVariantNumber={_.nth(correctedVariantNumbers, index)}
+            lineNumber={_.nth(lineNumbers, index)}
+            variantNumber={_.nth(variantNumbers, index)}
             columns={columns[index]}
             maxColumns={maxColumns_}
             chapter={chapter}

--- a/src/corpus/ui/ChapterView.tsx
+++ b/src/corpus/ui/ChapterView.tsx
@@ -33,6 +33,7 @@ import _ from 'lodash'
 interface Props {
   chapter: ChapterDisplay
   correctedLineNumbers?: readonly number[]
+  correctedVariantNumbers?: readonly number[]
   expandLineLinks?: boolean
 }
 
@@ -83,6 +84,7 @@ export function ChapterViewTable({
   textService,
   activeLine,
   correctedLineNumbers,
+  correctedVariantNumbers,
   expandLineLinks,
 }: Props & {
   activeLine: string
@@ -105,6 +107,7 @@ export function ChapterViewTable({
             activeLine={activeLine}
             line={line}
             correctedLineNumber={_.nth(correctedLineNumbers, index)}
+            correctedVariantNumber={_.nth(correctedVariantNumbers, index)}
             columns={columns[index]}
             maxColumns={maxColumns_}
             chapter={chapter}

--- a/src/corpus/ui/ChapterViewLine.tsx
+++ b/src/corpus/ui/ChapterViewLine.tsx
@@ -96,6 +96,7 @@ export function ChapterViewLine({
   chapter,
   lineNumber,
   correctedLineNumber,
+  correctedVariantNumber,
   line,
   columns,
   maxColumns,
@@ -106,6 +107,7 @@ export function ChapterViewLine({
   chapter: ChapterDisplay
   lineNumber: number
   correctedLineNumber?: number
+  correctedVariantNumber?: number
   line: LineDisplay
   columns: readonly TextLineColumn[]
   maxColumns: number
@@ -121,6 +123,7 @@ export function ChapterViewLine({
           chapter={chapter}
           lineNumber={lineNumber}
           correctedLineNumber={correctedLineNumber}
+          correctedVariantNumber={correctedVariantNumber}
           line={line}
           variantNumber={variantNumber}
           columns={columns}
@@ -183,6 +186,7 @@ export function ChapterViewLineVariant({
   chapter,
   lineNumber,
   correctedLineNumber,
+  correctedVariantNumber,
   line,
   variantNumber,
   maxColumns,
@@ -193,6 +197,7 @@ export function ChapterViewLineVariant({
   chapter: ChapterDisplay
   lineNumber: number
   correctedLineNumber?: number
+  correctedVariantNumber?: number
   line: LineDisplay
   variantNumber: number
   columns: readonly TextLineColumn[]
@@ -237,15 +242,17 @@ export function ChapterViewLineVariant({
       lineNumber: _.isNil(correctedLineNumber)
         ? lineNumber
         : correctedLineNumber,
-      variantNumber: variantNumber,
+      variantNumber: _.isNil(correctedVariantNumber)
+        ? lineNumber
+        : correctedVariantNumber,
       textService: textService,
     }
     return new LineGroup(variant.reconstruction, lineInfo, highlightIndexSetter)
   }, [
     chapter.id,
     correctedLineNumber,
+    correctedVariantNumber,
     lineNumber,
-    variantNumber,
     textService,
     variant.reconstruction,
   ])

--- a/src/corpus/ui/ChapterViewLine.tsx
+++ b/src/corpus/ui/ChapterViewLine.tsx
@@ -95,8 +95,8 @@ function CollapsibleRow({
 export function ChapterViewLine({
   chapter,
   lineIndex,
-  correctedLineNumber,
-  correctedVariantNumber,
+  lineNumber,
+  variantNumber,
   line,
   columns,
   maxColumns,
@@ -106,8 +106,8 @@ export function ChapterViewLine({
 }: {
   chapter: ChapterDisplay
   lineIndex: number
-  correctedLineNumber?: number
-  correctedVariantNumber?: number
+  lineNumber?: number
+  variantNumber?: number
   line: LineDisplay
   columns: readonly TextLineColumn[]
   maxColumns: number
@@ -122,8 +122,8 @@ export function ChapterViewLine({
           key={variantIndex}
           chapter={chapter}
           lineIndex={lineIndex}
-          correctedLineNumber={correctedLineNumber}
-          correctedVariantNumber={correctedVariantNumber}
+          lineNumber={lineNumber}
+          variantNumber={variantNumber}
           line={line}
           variantIndex={variantIndex}
           columns={columns}
@@ -185,8 +185,8 @@ function TransliterationColumns({
 export function ChapterViewLineVariant({
   chapter,
   lineIndex,
-  correctedLineNumber,
-  correctedVariantNumber,
+  lineNumber,
+  variantNumber,
   line,
   variantIndex,
   maxColumns,
@@ -196,8 +196,8 @@ export function ChapterViewLineVariant({
 }: {
   chapter: ChapterDisplay
   lineIndex: number
-  correctedLineNumber?: number
-  correctedVariantNumber?: number
+  lineNumber?: number
+  variantNumber?: number
   line: LineDisplay
   variantIndex: number
   columns: readonly TextLineColumn[]
@@ -239,15 +239,15 @@ export function ChapterViewLineVariant({
   const lineGroup = useMemo(() => {
     const lineInfo: LineInfo = {
       chapterId: chapter.id,
-      lineNumber: correctedLineNumber ?? lineIndex,
-      variantNumber: correctedVariantNumber ?? variantIndex,
+      lineNumber: lineNumber ?? lineIndex,
+      variantNumber: variantNumber ?? variantIndex,
       textService: textService,
     }
     return new LineGroup(variant.reconstruction, lineInfo, highlightIndexSetter)
   }, [
     chapter.id,
-    correctedLineNumber,
-    correctedVariantNumber,
+    lineNumber,
+    variantNumber,
     lineIndex,
     variantIndex,
     textService,

--- a/src/corpus/ui/ChapterViewLine.tsx
+++ b/src/corpus/ui/ChapterViewLine.tsx
@@ -239,12 +239,8 @@ export function ChapterViewLineVariant({
   const lineGroup = useMemo(() => {
     const lineInfo: LineInfo = {
       chapterId: chapter.id,
-      lineNumber: _.isNil(correctedLineNumber)
-        ? lineNumber
-        : correctedLineNumber,
-      variantNumber: _.isNil(correctedVariantNumber)
-        ? lineNumber
-        : correctedVariantNumber,
+      lineNumber: correctedLineNumber ?? lineNumber,
+      variantNumber: correctedVariantNumber ?? variantNumber,
       textService: textService,
     }
     return new LineGroup(variant.reconstruction, lineInfo, highlightIndexSetter)
@@ -253,6 +249,7 @@ export function ChapterViewLineVariant({
     correctedLineNumber,
     correctedVariantNumber,
     lineNumber,
+    variantNumber,
     textService,
     variant.reconstruction,
   ])

--- a/src/corpus/ui/ChapterViewLine.tsx
+++ b/src/corpus/ui/ChapterViewLine.tsx
@@ -94,7 +94,7 @@ function CollapsibleRow({
 
 export function ChapterViewLine({
   chapter,
-  lineNumber,
+  lineIndex,
   correctedLineNumber,
   correctedVariantNumber,
   line,
@@ -105,7 +105,7 @@ export function ChapterViewLine({
   expandLineLinks,
 }: {
   chapter: ChapterDisplay
-  lineNumber: number
+  lineIndex: number
   correctedLineNumber?: number
   correctedVariantNumber?: number
   line: LineDisplay
@@ -117,15 +117,15 @@ export function ChapterViewLine({
 }): JSX.Element {
   return (
     <>
-      {line.variants.map((variants, variantNumber) => (
+      {line.variants.map((variants, variantIndex) => (
         <ChapterViewLineVariant
-          key={variantNumber}
+          key={variantIndex}
           chapter={chapter}
-          lineNumber={lineNumber}
+          lineIndex={lineIndex}
           correctedLineNumber={correctedLineNumber}
           correctedVariantNumber={correctedVariantNumber}
           line={line}
-          variantNumber={variantNumber}
+          variantIndex={variantIndex}
           columns={columns}
           maxColumns={maxColumns}
           textService={textService}
@@ -184,22 +184,22 @@ function TransliterationColumns({
 
 export function ChapterViewLineVariant({
   chapter,
-  lineNumber,
+  lineIndex,
   correctedLineNumber,
   correctedVariantNumber,
   line,
-  variantNumber,
+  variantIndex,
   maxColumns,
   textService,
   activeLine,
   expandLineLinks,
 }: {
   chapter: ChapterDisplay
-  lineNumber: number
+  lineIndex: number
   correctedLineNumber?: number
   correctedVariantNumber?: number
   line: LineDisplay
-  variantNumber: number
+  variantIndex: number
   columns: readonly TextLineColumn[]
   maxColumns: number
   textService: TextService
@@ -213,7 +213,7 @@ export function ChapterViewLineVariant({
     toggleColumns + lineNumberColumns + maxColumns + translationColumns
   const [
     {
-      [lineNumber]: {
+      [lineIndex]: {
         score: showScore,
         notes: showNotes,
         parallels: showParallels,
@@ -225,8 +225,8 @@ export function ChapterViewLineVariant({
   ] = useContext(RowsContext)
 
   const [{ language }] = useContext(TranslationContext)
-  const variant = line.variants[variantNumber]
-  const isPrimaryVariant = variantNumber === 0
+  const variant = line.variants[variantIndex]
+  const isPrimaryVariant = variantIndex === 0
   const hasIntertext = variant.intertext.length > 0
 
   const columns = useMemo(() => createColumns(variant.reconstruction), [
@@ -239,8 +239,8 @@ export function ChapterViewLineVariant({
   const lineGroup = useMemo(() => {
     const lineInfo: LineInfo = {
       chapterId: chapter.id,
-      lineNumber: correctedLineNumber ?? lineNumber,
-      variantNumber: correctedVariantNumber ?? variantNumber,
+      lineNumber: correctedLineNumber ?? lineIndex,
+      variantNumber: correctedVariantNumber ?? variantIndex,
       textService: textService,
     }
     return new LineGroup(variant.reconstruction, lineInfo, highlightIndexSetter)
@@ -248,8 +248,8 @@ export function ChapterViewLineVariant({
     chapter.id,
     correctedLineNumber,
     correctedVariantNumber,
-    lineNumber,
-    variantNumber,
+    lineIndex,
+    variantIndex,
     textService,
     variant.reconstruction,
   ])
@@ -257,7 +257,7 @@ export function ChapterViewLineVariant({
   const transliteration = useMemo(
     () => (
       <TransliterationColumns
-        variantNumber={variantNumber}
+        variantNumber={variantIndex}
         line={line}
         activeLine={activeLine}
         columns={columns}
@@ -268,7 +268,7 @@ export function ChapterViewLineVariant({
       />
     ),
     [
-      variantNumber,
+      variantIndex,
       line,
       activeLine,
       columns,
@@ -350,7 +350,7 @@ export function ChapterViewLineVariant({
         <td
           className="chapter-display__toggle"
           onClick={() =>
-            dispatchRows({ type: 'toggle', target: 'score', row: lineNumber })
+            dispatchRows({ type: 'toggle', target: 'score', row: lineIndex })
           }
         >
           {isPrimaryVariant && scoreCaret}
@@ -359,7 +359,7 @@ export function ChapterViewLineVariant({
         <td
           className="chapter-display__toggle"
           onClick={() =>
-            dispatchRows({ type: 'toggle', target: 'notes', row: lineNumber })
+            dispatchRows({ type: 'toggle', target: 'notes', row: lineIndex })
           }
         >
           {variant.note && (
@@ -382,7 +382,7 @@ export function ChapterViewLineVariant({
             dispatchRows({
               type: 'toggle',
               target: 'parallels',
-              row: lineNumber,
+              row: lineIndex,
             })
           }
         >

--- a/src/corpus/ui/search/CorpusSearchResult.tsx
+++ b/src/corpus/ui/search/CorpusSearchResult.tsx
@@ -61,6 +61,7 @@ const ChapterResult = withData<
     data: chapterDisplay,
     chapterId,
     lines,
+    variants,
     textService,
     variantsToShow,
   }): JSX.Element => {
@@ -81,6 +82,7 @@ const ChapterResult = withData<
                 textService={textService}
                 chapter={chapterDisplay}
                 correctedLineNumbers={lines}
+                correctedVariantNumbers={variants}
                 activeLine={''}
                 expandLineLinks={true}
               />

--- a/src/corpus/ui/search/CorpusSearchResult.tsx
+++ b/src/corpus/ui/search/CorpusSearchResult.tsx
@@ -81,8 +81,8 @@ const ChapterResult = withData<
               <ChapterViewTable
                 textService={textService}
                 chapter={chapterDisplay}
-                correctedLineNumbers={lines}
-                correctedVariantNumbers={variants}
+                lineNumbers={lines}
+                variantNumbers={variants}
                 activeLine={''}
                 expandLineLinks={true}
               />


### PR DESCRIPTION
Fixes an error that only the first variant in corpus searches would be shown, even if the match is in the second or later variants.