### PR TITLE
Show Variant Label in Partial Search Results

### DIFF
--- a/src/corpus/application/TextService.test.ts
+++ b/src/corpus/application/TextService.test.ts
@@ -27,11 +27,7 @@ import {
   referenceDtoFactory,
   referenceFactory,
 } from 'test-support/bibliography-fixtures'
-import {
-  LineDetails,
-  LineVariantDetails,
-  ManuscriptLineDisplay,
-} from 'corpus/domain/line-details'
+import { LineDetails, ManuscriptLineDisplay } from 'corpus/domain/line-details'
 import { TextLine } from 'transliteration/domain/text-line'
 import { ManuscriptTypes, OldSiglum } from 'corpus/domain/manuscript'
 
@@ -46,7 +42,10 @@ import { ParallelLine } from 'transliteration/domain/parallel-line'
 import { fromTransliterationLineDto } from 'transliteration/application/dtos'
 import { wordFactory } from 'test-support/word-fixtures'
 import createReference from 'bibliography/application/createReference'
-import { dictionaryLineDisplayDto } from 'test-support/dictionary-line-fixtures'
+import {
+  dictionaryLineDisplayDto,
+  lineVariantDisplayFactory,
+} from 'test-support/dictionary-line-fixtures'
 import { fromDictionaryLineDto } from './dtos'
 
 jest.mock('bibliography/application/BibliographyService')
@@ -269,21 +268,18 @@ const chapterDisplay = new ChapterDisplay(
     translation: dto.translation.map(
       (translation) => new TranslationLine(translation)
     ),
-    variants: dto.variants.map(
-      (variant) =>
-        new LineVariantDetails(
-          variant.reconstruction.map((token, index) => ({
-            ...token,
-            sentenceIndex: index,
-          })),
-          variant.note && new NoteLine(variant.note),
-          variant.manuscripts,
-          variant.parallelLines.map(
-            (parallel) => fromTransliterationLineDto(parallel) as ParallelLine
-          ),
-          variant.intertext
-        )
-    ),
+    variants: dto.variants.map((variant, index) => ({
+      ...variant,
+      reconstruction: variant.reconstruction.map((token, index) => ({
+        ...token,
+        sentenceIndex: index,
+      })),
+      note: variant.note && new NoteLine(variant.note),
+      parallelLines: variant.parallelLines.map(
+        (parallel) => fromTransliterationLineDto(parallel) as ParallelLine
+      ),
+      isPrimaryVariant: index === 0,
+    })),
   })),
   chapterDisplayDto.record,
   chapterDisplayDto.atf
@@ -348,9 +344,9 @@ const testData: TestData<TextService>[] = [
     apiClient.fetchJson,
     new LineDetails(
       [
-        new LineVariantDetails(
-          [],
-          new NoteLine({
+        lineVariantDisplayFactory.build({
+          reconstruction: [],
+          note: new NoteLine({
             content: [],
             parts: [
               {
@@ -359,7 +355,7 @@ const testData: TestData<TextService>[] = [
               },
             ],
           }),
-          [
+          manuscripts: [
             new ManuscriptLineDisplay(
               Provenances.Nippur,
               PeriodModifiers['Early'],
@@ -377,9 +373,7 @@ const testData: TestData<TextService>[] = [
               'X.1'
             ),
           ],
-          [],
-          []
-        ),
+        }),
       ],
       0
     ),
@@ -423,6 +417,8 @@ const testData: TestData<TextService>[] = [
           ],
           parallelLines: [],
           intertext: [],
+          originalIndex: 0,
+          isPrimaryVariant: true,
         },
       ],
     })

--- a/src/corpus/application/TextService.test.ts
+++ b/src/corpus/application/TextService.test.ts
@@ -258,8 +258,9 @@ const chapterDisplay = new ChapterDisplay(
   chapterDisplayDto.textName,
   chapterDisplayDto.isSingleStage,
   chapterDisplayDto.title,
-  chapterDisplayDto.lines.map((dto) => ({
+  chapterDisplayDto.lines.map((dto, index) => ({
     ...dto,
+    originalIndex: index,
     oldLineNumbers:
       dto.oldLineNumbers?.map((oldLineNumberDto) => ({
         number: oldLineNumberDto.number,

--- a/src/corpus/application/dtos.ts
+++ b/src/corpus/application/dtos.ts
@@ -8,6 +8,7 @@ import {
   ChapterDisplay,
   DictionaryLineDisplay,
   LineDisplay,
+  LineVariantDisplay,
 } from 'corpus/domain/chapter'
 import { ChapterLemmatization } from 'corpus/domain/lemmatization'
 import {
@@ -18,11 +19,7 @@ import {
   Line,
   LineVariant,
 } from 'corpus/domain/line'
-import {
-  LineDetails,
-  LineVariantDetails,
-  ManuscriptLineDisplay,
-} from 'corpus/domain/line-details'
+import { LineDetails, ManuscriptLineDisplay } from 'corpus/domain/line-details'
 import {
   Manuscript,
   ManuscriptTypes,
@@ -58,8 +55,8 @@ import { ChapterInfoLine } from 'corpus/domain/ChapterInfo'
 import { createResearchProject } from 'research-projects/researchProject'
 
 export type LineVariantDisplayDto = Pick<
-  LineVariantDetails,
-  'reconstruction' | 'manuscripts' | 'intertext'
+  LineVariantDisplay,
+  'originalIndex' | 'reconstruction' | 'manuscripts' | 'intertext'
 > & {
   note: Omit<NoteLineDto, 'type'> | null
   parallelLines: ParallelLineDto[]
@@ -234,16 +231,14 @@ function fromManuscriptLineDisplay(manuscript): ManuscriptLineDisplay {
   )
 }
 
-function fromLineVariantDisplay(variant): LineVariantDetails {
-  return new LineVariantDetails(
-    variant.reconstruction,
-    variant.note && new NoteLine(variant.note),
-    variant.manuscripts.map((manuscript) =>
+function fromLineVariantDisplay(variant): LineVariantDisplay {
+  return {
+    ...variant,
+    note: variant.note && new NoteLine(variant.note),
+    manuscripts: variant.manuscripts.map((manuscript) =>
       fromManuscriptLineDisplay(manuscript)
     ),
-    variant.parallelLines,
-    variant.intertext
-  )
+  }
 }
 
 export function fromLineDetailsDto(line, activeVariant: number): LineDetails {

--- a/src/corpus/application/dtos.ts
+++ b/src/corpus/application/dtos.ts
@@ -69,7 +69,10 @@ export type OldLineNumberDto = {
 
 export type LineDisplayDto = Pick<
   LineDisplay,
-  'number' | 'isSecondLineOfParallelism' | 'isBeginningOfSection'
+  | 'number'
+  | 'isSecondLineOfParallelism'
+  | 'isBeginningOfSection'
+  | 'originalIndex'
 > & {
   translation: {
     language: string

--- a/src/corpus/domain/LineDetails.test.ts
+++ b/src/corpus/domain/LineDetails.test.ts
@@ -2,8 +2,9 @@ import { manuscriptLineDisplayFactory } from 'test-support/line-details-fixtures
 import { implicitFirstColumn } from 'test-support/lines/text-columns'
 import textLine from 'test-support/lines/text-line'
 import { EmptyLine } from 'transliteration/domain/line'
-import { LineDetails, LineVariantDetails } from './line-details'
+import { LineDetails } from './line-details'
 import { compareManuscripts } from './manuscript'
+import { lineVariantDisplayFactory } from 'test-support/dictionary-line-fixtures'
 
 const empty = manuscriptLineDisplayFactory.build(
   {},
@@ -20,22 +21,51 @@ const manyColumns = manuscriptLineDisplayFactory.build(
 
 test.each([
   [new LineDetails([], 0), 1],
-  [new LineDetails([new LineVariantDetails([], null, [], [], [])], 0), 1],
-  [new LineDetails([new LineVariantDetails([], null, [empty], [], [])], 0), 1],
   [
-    new LineDetails([new LineVariantDetails([], null, [oneColumn], [], [])], 0),
+    new LineDetails(
+      [
+        lineVariantDisplayFactory.build({
+          reconstruction: [],
+          manuscripts: [],
+        }),
+      ],
+      0
+    ),
+    1,
+  ],
+  [
+    new LineDetails(
+      [
+        lineVariantDisplayFactory.build({
+          reconstruction: [],
+          manuscripts: [empty],
+        }),
+      ],
+
+      0
+    ),
+    1,
+  ],
+  [
+    new LineDetails(
+      [
+        lineVariantDisplayFactory.build({
+          reconstruction: [],
+          manuscripts: [oneColumn],
+        }),
+      ],
+      0
+    ),
     textLine.numberOfColumns,
   ],
   [
     new LineDetails(
-      [new LineVariantDetails([], null, [manyColumns], [], [])],
-      0
-    ),
-    implicitFirstColumn.numberOfColumns,
-  ],
-  [
-    new LineDetails(
-      [new LineVariantDetails([], null, [empty, manyColumns], [], [])],
+      [
+        lineVariantDisplayFactory.build({
+          reconstruction: [],
+          manuscripts: [manyColumns],
+        }),
+      ],
       0
     ),
     implicitFirstColumn.numberOfColumns,
@@ -43,8 +73,28 @@ test.each([
   [
     new LineDetails(
       [
-        new LineVariantDetails([], null, [manyColumns], [], []),
-        new LineVariantDetails([], null, [oneColumn], [], []),
+        lineVariantDisplayFactory.build({
+          reconstruction: [],
+          manuscripts: [empty, manyColumns],
+        }),
+      ],
+      0
+    ),
+    implicitFirstColumn.numberOfColumns,
+  ],
+  [
+    new LineDetails(
+      [
+        lineVariantDisplayFactory.build({
+          reconstruction: [],
+          manuscripts: [manyColumns],
+        }),
+        lineVariantDisplayFactory.build({
+          reconstruction: [],
+          manuscripts: [oneColumn],
+          originalIndex: 1,
+          isPrimaryVariant: false,
+        }),
       ],
       0
     ),
@@ -57,8 +107,16 @@ test.each([
 test('sortedManuscripts', () => {
   const lineDetails = new LineDetails(
     [
-      new LineVariantDetails([], null, [manyColumns], [], []),
-      new LineVariantDetails([], null, [oneColumn], [], []),
+      lineVariantDisplayFactory.build({
+        reconstruction: [],
+        manuscripts: [manyColumns],
+      }),
+      lineVariantDisplayFactory.build({
+        reconstruction: [],
+        manuscripts: [oneColumn],
+        originalIndex: 1,
+        isPrimaryVariant: false,
+      }),
     ],
     0
   )

--- a/src/corpus/domain/chapter.ts
+++ b/src/corpus/domain/chapter.ts
@@ -80,6 +80,7 @@ export interface LineDisplay {
   readonly isBeginningOfSection: boolean
   readonly translation: ReadonlyArray<TranslationLine>
   readonly variants: ReadonlyArray<LineVariantDisplay>
+  readonly originalIndex: number
 }
 
 export interface DictionaryLineDisplay {

--- a/src/corpus/domain/chapter.ts
+++ b/src/corpus/domain/chapter.ts
@@ -69,6 +69,8 @@ export interface LineVariantDisplay {
   readonly manuscripts: ReadonlyArray<ManuscriptLineDisplay>
   readonly parallelLines: ReadonlyArray<ParallelLine>
   readonly intertext: ReadonlyArray<MarkupPart>
+  readonly originalIndex: number
+  readonly isPrimaryVariant: boolean
 }
 
 export interface LineDisplay {

--- a/src/corpus/domain/line-details.ts
+++ b/src/corpus/domain/line-details.ts
@@ -18,11 +18,9 @@ import {
 } from 'transliteration/domain/type-guards'
 import { AbstractLine } from 'transliteration/domain/abstract-line'
 import { NoteLine } from 'transliteration/domain/note-line'
-import { ParallelLine } from 'transliteration/domain/parallel-line'
-import { MarkupPart } from 'transliteration/domain/markup'
-import { Token } from 'transliteration/domain/token'
 import Reference from 'bibliography/domain/Reference'
 import { Joins } from 'fragmentarium/domain/join'
+import { LineVariantDisplay } from './chapter'
 
 export class ManuscriptLineDisplay {
   readonly [immerable] = true
@@ -79,23 +77,11 @@ export class ManuscriptLineDisplay {
   }
 }
 
-export class LineVariantDetails {
-  readonly [immerable] = true
-
-  constructor(
-    readonly reconstruction: readonly Token[],
-    readonly note: NoteLine | null,
-    readonly manuscripts: readonly ManuscriptLineDisplay[],
-    readonly parallelLines: ParallelLine[],
-    readonly intertext: MarkupPart[]
-  ) {}
-}
-
 export class LineDetails {
   readonly [immerable] = true
 
   constructor(
-    readonly variants: readonly LineVariantDetails[],
+    readonly variants: readonly LineVariantDisplay[],
     readonly activeVariant: number
   ) {}
 

--- a/src/corpus/ui/ChapterView.integration.test.ts
+++ b/src/corpus/ui/ChapterView.integration.test.ts
@@ -59,6 +59,7 @@ describe('Display chapter', () => {
     fakeApi.expectLineDetails(chapter.id, 0, {
       variants: [
         {
+          originalIndex: 0,
           reconstruction: [],
           note: null,
           manuscripts: [
@@ -171,10 +172,11 @@ describe('Display chapter', () => {
   })
 
   test('Sidebar', async () => {
-    chapter.lines.forEach((line, index) => {
-      fakeApi.expectLineDetails(chapter.id, index, {
+    chapter.lines.forEach((line) => {
+      fakeApi.expectLineDetails(chapter.id, line.originalIndex, {
         variants: [
           {
+            originalIndex: 0,
             manuscripts: [
               {
                 provenance: 'Standard Text',
@@ -184,7 +186,7 @@ describe('Display chapter', () => {
                 oldSigla: [],
                 type: 'None',
                 labels: [],
-                line: lines[index],
+                line: lines[line.originalIndex],
                 paratext: [singleRulingDto],
                 references: [],
                 joins: [],

--- a/src/corpus/ui/ChapterView.sass
+++ b/src/corpus/ui/ChapterView.sass
@@ -8,6 +8,9 @@
 
         & ~ &
             padding-left: 2em
+        
+        .chapter-display__variant
+            padding-left: 1em
 
     &__line-number
         text-align: right

--- a/src/corpus/ui/ChapterView.tsx
+++ b/src/corpus/ui/ChapterView.tsx
@@ -152,8 +152,7 @@ export function PartialChapterViewTable({
                 activeLine={activeLine}
                 line={line}
                 lineNumber={_.nth(lineNumbers, pos)}
-                variantNumber={_.nth(variantNumbers, pos)}
-                variantIndex={variantIndex}
+                variant={variant}
                 columns={columns[lineIndex]}
                 maxColumns={maxColumns_}
                 chapter={chapter}

--- a/src/corpus/ui/ChapterView.tsx
+++ b/src/corpus/ui/ChapterView.tsx
@@ -33,8 +33,6 @@ import MarkupService from 'markup/application/MarkupService'
 
 interface Props {
   chapter: ChapterDisplay
-  lineNumbers?: readonly number[]
-  variantNumbers?: readonly number[]
   expandLineLinks?: boolean
 }
 
@@ -122,8 +120,6 @@ export function PartialChapterViewTable({
   chapter,
   textService,
   activeLine,
-  lineNumbers,
-  variantNumbers,
   expandLineLinks,
 }: Props & {
   activeLine: string
@@ -138,29 +134,29 @@ export function PartialChapterViewTable({
   )
   const maxColumns_ = maxColumns(columns)
 
-  let pos = -1
   return (
     <table className="chapter-display">
       <tbody>
-        {chapter.lines.map((line, lineIndex) =>
-          line.variants.map((variant, variantIndex) => {
-            pos++
-            return (
-              <ChapterViewLineVariant
-                key={pos}
-                activeLine={activeLine}
-                line={line}
-                variant={variant}
-                columns={columns[lineIndex]}
-                maxColumns={maxColumns_}
-                chapter={chapter}
-                lineIndex={lineIndex}
-                textService={textService}
-                expandLineLinks={expandLineLinks}
-              />
-            )
-          })
-        )}
+        {chapter.lines.map((line, lineIndex) => (
+          <React.Fragment key={lineIndex}>
+            {line.variants.map((variant, variantIndex) => {
+              return (
+                <ChapterViewLineVariant
+                  key={variantIndex}
+                  activeLine={activeLine}
+                  line={line}
+                  variant={variant}
+                  columns={columns[lineIndex]}
+                  maxColumns={maxColumns_}
+                  chapter={chapter}
+                  lineIndex={lineIndex}
+                  textService={textService}
+                  expandLineLinks={expandLineLinks}
+                />
+              )
+            })}
+          </React.Fragment>
+        ))}
       </tbody>
     </table>
   )

--- a/src/corpus/ui/ChapterView.tsx
+++ b/src/corpus/ui/ChapterView.tsx
@@ -28,7 +28,6 @@ import { stageToAbbreviation } from 'common/period'
 
 import './ChapterView.sass'
 import WordService from 'dictionary/application/WordService'
-import _ from 'lodash'
 import { HeadTags } from 'router/head'
 import MarkupService from 'markup/application/MarkupService'
 
@@ -151,7 +150,6 @@ export function PartialChapterViewTable({
                 key={pos}
                 activeLine={activeLine}
                 line={line}
-                lineNumber={_.nth(lineNumbers, pos)}
                 variant={variant}
                 columns={columns[lineIndex]}
                 maxColumns={maxColumns_}

--- a/src/corpus/ui/ChapterView.tsx
+++ b/src/corpus/ui/ChapterView.tsx
@@ -85,6 +85,44 @@ export function ChapterViewTable({
   chapter,
   textService,
   activeLine,
+  expandLineLinks,
+}: Props & {
+  activeLine: string
+  textService: TextService
+}): JSX.Element {
+  const columns = useMemo(
+    () =>
+      chapter.lines.map((line) =>
+        createColumns(line.variants[0].reconstruction)
+      ),
+    [chapter.lines]
+  )
+  const maxColumns_ = maxColumns(columns)
+  return (
+    <table className="chapter-display">
+      <tbody>
+        {chapter.lines.map((line, index) => (
+          <ChapterViewLine
+            key={index}
+            activeLine={activeLine}
+            line={line}
+            columns={columns[index]}
+            maxColumns={maxColumns_}
+            chapter={chapter}
+            lineIndex={index}
+            textService={textService}
+            expandLineLinks={expandLineLinks}
+          />
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+export function PartialChapterViewTable({
+  chapter,
+  textService,
+  activeLine,
   lineNumbers,
   variantNumbers,
   expandLineLinks,
@@ -163,7 +201,7 @@ function ChapterView({
       chapter={chapter}
       textService={textService}
       activeLine={activeLine}
-    ></ChapterViewTable>
+    />
   )
 
   return (

--- a/src/corpus/ui/ChapterView.tsx
+++ b/src/corpus/ui/ChapterView.tsx
@@ -19,7 +19,7 @@ import Download from 'corpus/ui/Download'
 import GotoButton from './GotoButton'
 import SubmitCorrectionsButton from 'common/SubmitCorrectionsButton'
 import TextService from 'corpus/application/TextService'
-import { ChapterViewLine, ChapterViewLineVariant } from './ChapterViewLine'
+import { ChapterViewLine } from './ChapterViewLine'
 import RowsContext, { useRowsContext } from './RowsContext'
 import { SideBar } from './ChapterViewSideBar'
 import { HowToCite } from './HowToCite'
@@ -110,52 +110,6 @@ export function ChapterViewTable({
             textService={textService}
             expandLineLinks={expandLineLinks}
           />
-        ))}
-      </tbody>
-    </table>
-  )
-}
-
-export function PartialChapterViewTable({
-  chapter,
-  textService,
-  activeLine,
-  expandLineLinks,
-}: Props & {
-  activeLine: string
-  textService: TextService
-}): JSX.Element {
-  const columns = useMemo(
-    () =>
-      chapter.lines.map((line) =>
-        createColumns(line.variants[0].reconstruction)
-      ),
-    [chapter.lines]
-  )
-  const maxColumns_ = maxColumns(columns)
-
-  return (
-    <table className="chapter-display">
-      <tbody>
-        {chapter.lines.map((line, lineIndex) => (
-          <React.Fragment key={lineIndex}>
-            {line.variants.map((variant, variantIndex) => {
-              return (
-                <ChapterViewLineVariant
-                  key={variantIndex}
-                  activeLine={activeLine}
-                  line={line}
-                  variant={variant}
-                  columns={columns[lineIndex]}
-                  maxColumns={maxColumns_}
-                  chapter={chapter}
-                  lineIndex={lineIndex}
-                  textService={textService}
-                  expandLineLinks={expandLineLinks}
-                />
-              )
-            })}
-          </React.Fragment>
         ))}
       </tbody>
     </table>

--- a/src/corpus/ui/ChapterView.tsx
+++ b/src/corpus/ui/ChapterView.tsx
@@ -19,7 +19,7 @@ import Download from 'corpus/ui/Download'
 import GotoButton from './GotoButton'
 import SubmitCorrectionsButton from 'common/SubmitCorrectionsButton'
 import TextService from 'corpus/application/TextService'
-import { ChapterViewLine } from './ChapterViewLine'
+import { ChapterViewLine, ChapterViewLineVariant } from './ChapterViewLine'
 import RowsContext, { useRowsContext } from './RowsContext'
 import { SideBar } from './ChapterViewSideBar'
 import { HowToCite } from './HowToCite'
@@ -138,24 +138,32 @@ export function PartialChapterViewTable({
     [chapter.lines]
   )
   const maxColumns_ = maxColumns(columns)
+
+  let pos = -1
   return (
     <table className="chapter-display">
       <tbody>
-        {chapter.lines.map((line, index) => (
-          <ChapterViewLine
-            key={index}
-            activeLine={activeLine}
-            line={line}
-            lineNumber={_.nth(lineNumbers, index)}
-            variantNumber={_.nth(variantNumbers, index)}
-            columns={columns[index]}
-            maxColumns={maxColumns_}
-            chapter={chapter}
-            lineIndex={index}
-            textService={textService}
-            expandLineLinks={expandLineLinks}
-          />
-        ))}
+        {chapter.lines.map((line, lineIndex) =>
+          line.variants.map((variant, variantIndex) => {
+            pos++
+            return (
+              <ChapterViewLineVariant
+                key={pos}
+                activeLine={activeLine}
+                line={line}
+                lineNumber={_.nth(lineNumbers, pos)}
+                variantNumber={_.nth(variantNumbers, pos)}
+                variantIndex={variantIndex}
+                columns={columns[lineIndex]}
+                maxColumns={maxColumns_}
+                chapter={chapter}
+                lineIndex={lineIndex}
+                textService={textService}
+                expandLineLinks={expandLineLinks}
+              />
+            )
+          })
+        )}
       </tbody>
     </table>
   )

--- a/src/corpus/ui/ChapterViewLine.tsx
+++ b/src/corpus/ui/ChapterViewLine.tsx
@@ -117,7 +117,7 @@ export function ChapterViewLine({
 }): JSX.Element {
   return (
     <>
-      {line.variants.map((variants, variantIndex) => (
+      {line.variants.map((variant, variantIndex) => (
         <ChapterViewLineVariant
           key={variantIndex}
           chapter={chapter}

--- a/src/corpus/ui/ChapterViewLine.tsx
+++ b/src/corpus/ui/ChapterViewLine.tsx
@@ -95,7 +95,6 @@ function CollapsibleRow({
 export function ChapterViewLine({
   chapter,
   lineIndex,
-  lineNumber,
   line,
   columns,
   maxColumns,
@@ -105,7 +104,6 @@ export function ChapterViewLine({
 }: {
   chapter: ChapterDisplay
   lineIndex: number
-  lineNumber?: number
   line: LineDisplay
   columns: readonly TextLineColumn[]
   maxColumns: number
@@ -120,7 +118,6 @@ export function ChapterViewLine({
           key={variantIndex}
           chapter={chapter}
           lineIndex={lineIndex}
-          lineNumber={lineNumber}
           line={line}
           variant={variant}
           columns={columns}
@@ -137,7 +134,6 @@ export function ChapterViewLine({
 export function ChapterViewLineVariant({
   chapter,
   lineIndex,
-  lineNumber,
   line,
   variant,
   maxColumns,
@@ -147,7 +143,6 @@ export function ChapterViewLineVariant({
 }: {
   chapter: ChapterDisplay
   lineIndex: number
-  lineNumber?: number
   variant: LineVariantDisplay
   line: LineDisplay
   columns: readonly TextLineColumn[]
@@ -182,21 +177,18 @@ export function ChapterViewLineVariant({
     variant.reconstruction,
   ])
 
-  // Forces an update; some time later we should re-implement lineGroup
-  // along the lines of RowsContext
   const [, highlightIndexSetter] = useState(0)
   const lineGroup = useMemo(() => {
     const lineInfo: LineInfo = {
       chapterId: chapter.id,
-      lineNumber: lineNumber ?? lineIndex,
+      lineNumber: line.originalIndex,
       variantNumber: variant.originalIndex,
       textService: textService,
     }
     return new LineGroup(variant.reconstruction, lineInfo, highlightIndexSetter)
   }, [
     chapter.id,
-    lineNumber,
-    lineIndex,
+    line.originalIndex,
     variant.originalIndex,
     variant.reconstruction,
     textService,

--- a/src/corpus/ui/ChapterViewLine.tsx
+++ b/src/corpus/ui/ChapterViewLine.tsx
@@ -194,8 +194,13 @@ export function ChapterViewLineVariant({
     textService,
   ])
 
-  const transliteration = useMemo(
-    () => (
+  const transliteration = useMemo(() => {
+    const variantLabel = (
+      <span className="chapter-display__variant">{`variant${numberToUnicodeSubscript(
+        variant.originalIndex
+      )}:\xa0`}</span>
+    )
+    return (
       <>
         {variant.isPrimaryVariant ? (
           <LineNumber
@@ -203,13 +208,11 @@ export function ChapterViewLineVariant({
             activeLine={activeLine}
             showOldLineNumbers={showOldLineNumbers}
             url={expandLineLinks ? chapter.url : null}
-          />
+          >
+            {variant.originalIndex > 0 && variantLabel}
+          </LineNumber>
         ) : (
-          <td className="chapter-display__variant">
-            <span>{`variant${numberToUnicodeSubscript(
-              variant.originalIndex
-            )}:\xa0`}</span>
-          </td>
+          <td>{variantLabel}</td>
         )}
         <LineColumns
           columns={columns}
@@ -219,21 +222,20 @@ export function ChapterViewLineVariant({
           isInLineGroup={true}
         />
       </>
-    ),
-    [
-      variant.isPrimaryVariant,
-      variant.originalIndex,
-      line,
-      activeLine,
-      showOldLineNumbers,
-      expandLineLinks,
-      chapter.url,
-      columns,
-      maxColumns,
-      showMeter,
-      showIpa,
-    ]
-  )
+    )
+  }, [
+    variant.isPrimaryVariant,
+    variant.originalIndex,
+    line,
+    activeLine,
+    showOldLineNumbers,
+    expandLineLinks,
+    chapter.url,
+    columns,
+    maxColumns,
+    showMeter,
+    showIpa,
+  ])
   const score = useMemo(
     () => (
       <CollapsibleRow show={showScore} id={scoreId} totalColumns={totalColumns}>

--- a/src/corpus/ui/LineNumber.tsx
+++ b/src/corpus/ui/LineNumber.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { ReactNode, useEffect, useRef } from 'react'
 import lineNumberToString, {
   lineNumberToAtf,
 } from 'transliteration/domain/lineNumberToString'
@@ -44,11 +44,13 @@ export default function LineNumber({
   activeLine,
   showOldLineNumbers,
   url,
+  children,
 }: {
   line: LineDisplay
   activeLine: string
   showOldLineNumbers: boolean
   url?: string | null
+  children?: ReactNode
 }): JSX.Element {
   const ref = useRef<HTMLAnchorElement>(null)
   const id = lineNumberToAtf(line.number)
@@ -92,6 +94,7 @@ export default function LineNumber({
           show={showOldLineNumbers}
         />
       )}
+      {children}
     </td>
   )
 }

--- a/src/corpus/ui/search/CorpusSearchResult.tsx
+++ b/src/corpus/ui/search/CorpusSearchResult.tsx
@@ -8,7 +8,7 @@ import _ from 'lodash'
 import { ResultPageButtons } from 'fragmentarium/ui/search/FragmentariumSearchResult'
 import { ChapterId, chapterIdToString } from 'transliteration/domain/chapter-id'
 import { ChapterDisplay } from 'corpus/domain/chapter'
-import { PartialChapterViewTable } from '../ChapterView'
+import { ChapterViewTable } from '../ChapterView'
 import RowsContext, { useRowsContext } from '../RowsContext'
 import TranslationContext, {
   useTranslationContext,
@@ -77,7 +77,7 @@ const ChapterResult = withData<
         <Row>
           <RowsContext.Provider value={rowsContext}>
             <TranslationContext.Provider value={translationContext}>
-              <PartialChapterViewTable
+              <ChapterViewTable
                 textService={textService}
                 chapter={chapterDisplay}
                 activeLine={''}

--- a/src/corpus/ui/search/CorpusSearchResult.tsx
+++ b/src/corpus/ui/search/CorpusSearchResult.tsx
@@ -8,7 +8,7 @@ import _ from 'lodash'
 import { ResultPageButtons } from 'fragmentarium/ui/search/FragmentariumSearchResult'
 import { ChapterId, chapterIdToString } from 'transliteration/domain/chapter-id'
 import { ChapterDisplay } from 'corpus/domain/chapter'
-import { ChapterViewTable } from '../ChapterView'
+import { PartialChapterViewTable } from '../ChapterView'
 import RowsContext, { useRowsContext } from '../RowsContext'
 import TranslationContext, {
   useTranslationContext,
@@ -78,7 +78,7 @@ const ChapterResult = withData<
         <Row>
           <RowsContext.Provider value={rowsContext}>
             <TranslationContext.Provider value={translationContext}>
-              <ChapterViewTable
+              <PartialChapterViewTable
                 textService={textService}
                 chapter={chapterDisplay}
                 lineNumbers={lines}

--- a/src/corpus/ui/search/CorpusSearchResult.tsx
+++ b/src/corpus/ui/search/CorpusSearchResult.tsx
@@ -61,7 +61,6 @@ const ChapterResult = withData<
     data: chapterDisplay,
     chapterId,
     lines,
-    variants,
     textService,
     variantsToShow,
   }): JSX.Element => {
@@ -81,8 +80,6 @@ const ChapterResult = withData<
               <PartialChapterViewTable
                 textService={textService}
                 chapter={chapterDisplay}
-                lineNumbers={lines}
-                variantNumbers={variants}
                 activeLine={''}
                 expandLineLinks={true}
               />

--- a/src/dictionary/ui/search/DictionaryLineGroup.tsx
+++ b/src/dictionary/ui/search/DictionaryLineGroup.tsx
@@ -1,5 +1,8 @@
 import React from 'react'
-import { DictionaryLineDisplay } from 'corpus/domain/chapter'
+import {
+  DictionaryLineDisplay,
+  LineVariantDisplay,
+} from 'corpus/domain/chapter'
 import { LineColumns } from 'transliteration/ui/line-tokens'
 import { TextId, textIdToString } from 'transliteration/domain/text-id'
 import _ from 'lodash'
@@ -9,7 +12,6 @@ import Markup from 'transliteration/ui/markup'
 import { stageToAbbreviation } from 'common/period'
 import InlineMarkdown from 'common/InlineMarkdown'
 import { createColumns, maxColumns } from 'transliteration/domain/columns'
-import { LineVariantDetails } from 'corpus/domain/line-details'
 import { isTextLine } from 'transliteration/domain/type-guards'
 import ManuscriptPopOver from 'corpus/ui/ManuscriptPopover'
 import { parallelLinePrefix } from 'transliteration/domain/parallel-line'
@@ -72,7 +74,7 @@ function DictionaryManuscriptLines({
   maxColumns,
   lemmaId,
 }: {
-  variant: LineVariantDetails
+  variant: LineVariantDisplay
   maxColumns: number
   lemmaId: string
 }): JSX.Element {

--- a/src/fragmentarium/domain/Date.ts
+++ b/src/fragmentarium/domain/Date.ts
@@ -74,14 +74,12 @@ export class MesopotamianDate {
     parameter: 'year' | 'day' | 'month',
     element?: string
   ): string {
-    console.log([parameter, element, this[parameter].value])
     element =
       !_.isEmpty(element) && typeof element == 'string'
         ? element
         : !_.isEmpty(this[parameter].value)
         ? this[parameter].value
         : '∅'
-    console.log(element)
     return this.brokenAndUncertainToString(parameter, element)
   }
 

--- a/src/fragmentarium/ui/search/FragmentariumSearch.test.tsx
+++ b/src/fragmentarium/ui/search/FragmentariumSearch.test.tsx
@@ -22,7 +22,8 @@ import TextService from 'corpus/application/TextService'
 import { ChapterDisplay } from 'corpus/domain/chapter'
 import { chapterDisplayFactory } from 'test-support/chapter-fixtures'
 import userEvent from '@testing-library/user-event'
-import { LineDetails, LineVariantDetails } from 'corpus/domain/line-details'
+import { LineDetails } from 'corpus/domain/line-details'
+import { lineVariantDisplayFactory } from 'test-support/dictionary-line-fixtures'
 
 const chance = new Chance('fragmentarium-search-test')
 
@@ -159,7 +160,15 @@ describe('Searching fragments by transliteration', () => {
       .mockReturnValueOnce(Promise.resolve(chapters[1]))
     textService.findChapterLine.mockReturnValue(
       Promise.resolve(
-        new LineDetails([new LineVariantDetails([], null, [], [], [])], 0)
+        new LineDetails(
+          [
+            lineVariantDisplayFactory.build({
+              reconstruction: [],
+              manuscripts: [],
+            }),
+          ],
+          0
+        )
       )
     )
 

--- a/src/fragmentarium/ui/search/__snapshots__/FragmentariumSearch.test.tsx.snap
+++ b/src/fragmentarium/ui/search/__snapshots__/FragmentariumSearch.test.tsx.snap
@@ -12344,11 +12344,11 @@ exports[`Searching fragments by transliteration Displays corpus results when cli
                       class="chapter-display__line-number"
                     >
                       <a
-                        href="https://www.ebl.lmu.de/corpus/D/443/2850995465879552/Uruk4/Cimatkiv%20rorleb%20wowmu%20amdis%20nuret%20bo%20mum%20bofcuz%20fa%20mij%20ag%20oku.#9"
+                        href="https://www.ebl.lmu.de/corpus/D/443/2850995465879552/Uruk4/Cimatkiv%20rorleb%20wowmu%20amdis%20nuret%20bo%20mum%20bofcuz%20fa%20mij%20ag%20oku.#10"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        9
+                        10
                       </a>
                     </td>
                     <td
@@ -12404,7 +12404,7 @@ exports[`Searching fragments by transliteration Displays corpus results when cli
                     <td
                       class="chapter-display__line-number"
                     >
-                      9
+                      10
                     </td>
                     <td
                       class="chapter-display__translation"
@@ -12462,11 +12462,11 @@ exports[`Searching fragments by transliteration Displays corpus results when cli
                       class="chapter-display__line-number"
                     >
                       <a
-                        href="https://www.ebl.lmu.de/corpus/D/443/2850995465879552/Uruk4/Cimatkiv%20rorleb%20wowmu%20amdis%20nuret%20bo%20mum%20bofcuz%20fa%20mij%20ag%20oku.#10"
+                        href="https://www.ebl.lmu.de/corpus/D/443/2850995465879552/Uruk4/Cimatkiv%20rorleb%20wowmu%20amdis%20nuret%20bo%20mum%20bofcuz%20fa%20mij%20ag%20oku.#11"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        10
+                        11
                       </a>
                     </td>
                     <td
@@ -12522,7 +12522,7 @@ exports[`Searching fragments by transliteration Displays corpus results when cli
                     <td
                       class="chapter-display__line-number"
                     >
-                      10
+                      11
                     </td>
                     <td
                       class="chapter-display__translation"
@@ -12610,11 +12610,11 @@ exports[`Searching fragments by transliteration Displays corpus results when cli
                       class="chapter-display__line-number"
                     >
                       <a
-                        href="https://www.ebl.lmu.de/corpus/L/3909/3560610589573120/MElam/Had%20vuhfofluk%20koosgo%20oppatdan%20nepa%20romlialo%20telpah%20wihse%20nor%20udjo%20mut%20nugut%20dubter%20bovlub%20zeugihiz%20kibop%20irusalle%20pov.#11"
+                        href="https://www.ebl.lmu.de/corpus/L/3909/3560610589573120/MElam/Had%20vuhfofluk%20koosgo%20oppatdan%20nepa%20romlialo%20telpah%20wihse%20nor%20udjo%20mut%20nugut%20dubter%20bovlub%20zeugihiz%20kibop%20irusalle%20pov.#12"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        11
+                        12
                       </a>
                     </td>
                     <td
@@ -12670,7 +12670,7 @@ exports[`Searching fragments by transliteration Displays corpus results when cli
                     <td
                       class="chapter-display__line-number"
                     >
-                      11
+                      12
                     </td>
                     <td
                       class="chapter-display__translation"
@@ -12728,11 +12728,11 @@ exports[`Searching fragments by transliteration Displays corpus results when cli
                       class="chapter-display__line-number"
                     >
                       <a
-                        href="https://www.ebl.lmu.de/corpus/L/3909/3560610589573120/MElam/Had%20vuhfofluk%20koosgo%20oppatdan%20nepa%20romlialo%20telpah%20wihse%20nor%20udjo%20mut%20nugut%20dubter%20bovlub%20zeugihiz%20kibop%20irusalle%20pov.#12"
+                        href="https://www.ebl.lmu.de/corpus/L/3909/3560610589573120/MElam/Had%20vuhfofluk%20koosgo%20oppatdan%20nepa%20romlialo%20telpah%20wihse%20nor%20udjo%20mut%20nugut%20dubter%20bovlub%20zeugihiz%20kibop%20irusalle%20pov.#13"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        12
+                        13
                       </a>
                     </td>
                     <td
@@ -12788,7 +12788,7 @@ exports[`Searching fragments by transliteration Displays corpus results when cli
                     <td
                       class="chapter-display__line-number"
                     >
-                      12
+                      13
                     </td>
                     <td
                       class="chapter-display__translation"

--- a/src/test-support/chapter-fixtures.ts
+++ b/src/test-support/chapter-fixtures.ts
@@ -77,6 +77,8 @@ export const lineDisplayDtoFactory = Factory.define<
     ],
     variants: [
       {
+        originalIndex: 0,
+        isPrimaryVariant: true,
         intertext: [
           {
             text: chance.sentence(),
@@ -152,6 +154,8 @@ export const lineDisplayFactory = Factory.define<
 
     variants: [
       {
+        originalIndex: 0,
+        isPrimaryVariant: true,
         intertext: [
           {
             text: chance.sentence(),

--- a/src/test-support/chapter-fixtures.ts
+++ b/src/test-support/chapter-fixtures.ts
@@ -44,10 +44,11 @@ export const chapterIdFactory = Factory.define<
 export const lineDisplayDtoFactory = Factory.define<
   LineDisplayDto,
   { chance: Chance.Chance }
->(({ associations, transientParams }) => {
+>(({ associations, sequence, transientParams }) => {
   const chance = transientParams.chance ?? defaultChance
   return {
     number: lineNumberFactory.build(),
+    originalIndex: associations.originalIndex ?? sequence,
     oldLineNumbers: associations.oldLineNumbers ?? [],
     isSecondLineOfParallelism: chance.bool(),
     isBeginningOfSection: chance.bool(),
@@ -120,10 +121,11 @@ export const lineDisplayDtoFactory = Factory.define<
 export const lineDisplayFactory = Factory.define<
   LineDisplay,
   { chance: Chance.Chance }
->(({ associations, transientParams }) => {
+>(({ associations, sequence, transientParams }) => {
   const chance = transientParams.chance ?? defaultChance
   return {
     number: lineNumberFactory.build(),
+    originalIndex: associations.originalIndex ?? sequence,
     oldLineNumbers: associations.oldLineNumbers ?? [],
     isSecondLineOfParallelism: chance.bool(),
     isBeginningOfSection: chance.bool(),
@@ -249,7 +251,16 @@ export const chapterDisplayFactory = ChapterDisplayFactory.define(
           type: 'StringPart',
         },
       ],
-      lineDisplayFactory.buildList(2, {}, { transient: { chance } }),
+      [
+        lineDisplayFactory.build(
+          { originalIndex: 0 },
+          { transient: { chance } }
+        ),
+        lineDisplayFactory.build(
+          { originalIndex: 1 },
+          { transient: { chance } }
+        ),
+      ],
       { authors: [], translators: [], publicationDate: '' },
       chance.sentence()
     )

--- a/src/test-support/dictionary-line-fixtures.ts
+++ b/src/test-support/dictionary-line-fixtures.ts
@@ -3,8 +3,11 @@ import Chance from 'chance'
 import { periods } from 'common/period'
 import _ from 'lodash'
 import { reconstructionTokens } from 'test-support/test-corpus-text'
-import { DictionaryLineDisplay } from 'corpus/domain/chapter'
-import { LineDetails, LineVariantDetails } from 'corpus/domain/line-details'
+import {
+  DictionaryLineDisplay,
+  LineVariantDisplay,
+} from 'corpus/domain/chapter'
+import { LineDetails } from 'corpus/domain/line-details'
 import { manuscriptLineDisplayFactory } from 'test-support/line-details-fixtures'
 import {
   lineDisplayDtoFactory,
@@ -14,18 +17,20 @@ import {
 
 const defaultChance = new Chance()
 
-export const lineVariantDetailsFactory = Factory.define<
-  LineVariantDetails,
+export const lineVariantDisplayFactory = Factory.define<
+  LineVariantDisplay,
   { chance: Chance.Chance }
->(({ associations, transientParams }) => {
-  return new LineVariantDetails(
+>(({ associations }) => ({
+  reconstruction:
     associations.reconstruction ?? _.cloneDeep(reconstructionTokens),
-    null,
+  note: associations.note ?? null,
+  manuscripts:
     associations.manuscripts ?? manuscriptLineDisplayFactory.buildList(1),
-    [],
-    []
-  )
-})
+  parallelLines: associations.parallelLines ?? [],
+  intertext: associations.intertext ?? [],
+  originalIndex: associations.originalIndex ?? 0,
+  isPrimaryVariant: associations.isPrimaryVariant ?? true,
+}))
 
 export const dictionaryLineDisplayFactory = Factory.define<
   DictionaryLineDisplay,
@@ -44,7 +49,15 @@ export const dictionaryLineDisplayFactory = Factory.define<
       lineDisplayFactory.build({}, { transient: { chance: chance } }),
     lineDetails:
       associations.lineDetails ??
-      new LineDetails([new LineVariantDetails([], null, [], [], [])], 0),
+      new LineDetails(
+        [
+          lineVariantDisplayFactory.build({
+            reconstruction: [],
+            manuscripts: [],
+          }),
+        ],
+        0
+      ),
   }
 })
 
@@ -55,7 +68,7 @@ export const dictionaryLineDisplayDto = {
   stage: 'stage',
   line: lineDisplayDtoFactory.build(),
   lineDetails: {
-    variants: lineVariantDetailsFactory.buildList(1),
+    variants: lineVariantDisplayFactory.buildList(1),
     activeVariant: 0,
   },
 }

--- a/src/test-support/fragment-fixtures.ts
+++ b/src/test-support/fragment-fixtures.ts
@@ -166,7 +166,7 @@ export const archaeologyFactory = Factory.define<Archaeology>(
     const chance = transientParams.chance ?? defaultChance
     return {
       excavationNumber: `${chance.word()}.${sequence}`,
-      site: chance.pickone([...Object.values(excavationSites), undefined]),
+      site: chance.pickone(Object.values(excavationSites)),
       isRegularExcavation: chance.bool(),
     }
   }

--- a/src/transliteration/ui/LineGroup.test.ts
+++ b/src/transliteration/ui/LineGroup.test.ts
@@ -1,4 +1,4 @@
-import { LineDetails, LineVariantDetails } from 'corpus/domain/line-details'
+import { LineDetails } from 'corpus/domain/line-details'
 import { manuscriptLineDisplayFactory } from 'test-support/line-details-fixtures'
 import {
   highlightIndexSetterMock,
@@ -7,13 +7,19 @@ import {
 import { implicitFirstColumn } from 'test-support/lines/text-columns'
 import { LemmatizableToken } from 'transliteration/domain/token'
 import { LineToken } from './line-tokens'
+import { lineVariantDisplayFactory } from 'test-support/dictionary-line-fixtures'
 
 const manuscriptLine = manuscriptLineDisplayFactory.build(
   {},
   { associations: { line: implicitFirstColumn } }
 )
 const lineDetails = new LineDetails(
-  [new LineVariantDetails([], null, [manuscriptLine], [], [])],
+  [
+    lineVariantDisplayFactory.build({
+      reconstruction: [],
+      manuscripts: [manuscriptLine],
+    }),
+  ],
   0
 )
 const lineTokens = manuscriptLine.line.content.map(

--- a/src/transliteration/ui/WordInfoAlignments.test.tsx
+++ b/src/transliteration/ui/WordInfoAlignments.test.tsx
@@ -25,10 +25,11 @@ import {
   manuscriptLineDto,
   variantTokenDto,
 } from 'test-support/word-info-fixtures'
-import { LineDetails, LineVariantDetails } from 'corpus/domain/line-details'
+import { LineDetails } from 'corpus/domain/line-details'
 import { manuscriptLineDisplayFactory } from 'test-support/line-details-fixtures'
 import { TextLine } from 'transliteration/domain/text-line'
 import { LineGroup } from './LineGroup'
+import { lineVariantDisplayFactory } from 'test-support/dictionary-line-fixtures'
 
 jest.mock('dictionary/application/WordService')
 jest.mock('corpus/application/TextService')
@@ -97,12 +98,22 @@ const variantManuscriptLine = manuscriptLineDisplayFactory.build(
 )
 
 const lineDetails = new LineDetails(
-  [new LineVariantDetails([], null, [manuscriptLine], [], [])],
+  [
+    lineVariantDisplayFactory.build({
+      reconstruction: [],
+      manuscripts: [manuscriptLine],
+    }),
+  ],
   0
 )
 
 const lineDetailsWithVariant = new LineDetails(
-  [new LineVariantDetails([], null, [variantManuscriptLine], [], [])],
+  [
+    lineVariantDisplayFactory.build({
+      reconstruction: [],
+      manuscripts: [variantManuscriptLine],
+    }),
+  ],
   0
 )
 


### PR DESCRIPTION
When only the 2nd variant matches, e.g., in https://www.ebl.lmu.de/fragmentarium/search/?transliteration=ka-li#corpus in "Literature > Poem of Creation (Enūma eliš) > Standard Babylonian I", line 61, it would display it as if it was the reconstruction, which is confusing. With this change, it shows the variant label in addition to the line number in such cases.