### PR TITLE
Show Variant Label in Partial Search Results

### DIFF
--- a/src/corpus/ui/ChapterView.sass
+++ b/src/corpus/ui/ChapterView.sass
@@ -9,6 +9,9 @@
         & ~ &
             padding-left: 2em
 
+        .chapter-display__variant
+            padding-left: 1em
+
     &__line-number
         text-align: right
 

--- a/src/corpus/ui/ChapterViewLine.tsx
+++ b/src/corpus/ui/ChapterViewLine.tsx
@@ -194,8 +194,13 @@ export function ChapterViewLineVariant({
     textService,
   ])
 
-  const transliteration = useMemo(
-    () => (
+  const transliteration = useMemo(() => {
+    const variantLabel = (
+      <span className="chapter-display__variant">{`variant${numberToUnicodeSubscript(
+        variant.originalIndex
+      )}:\xa0`}</span>
+    )
+    return (
       <>
         {variant.isPrimaryVariant ? (
           <LineNumber
@@ -203,13 +208,11 @@ export function ChapterViewLineVariant({
             activeLine={activeLine}
             showOldLineNumbers={showOldLineNumbers}
             url={expandLineLinks ? chapter.url : null}
-          />
+          >
+            {variant.originalIndex > 0 && variantLabel}
+          </LineNumber>
         ) : (
-          <td className="chapter-display__variant">
-            <span>{`variant${numberToUnicodeSubscript(
-              variant.originalIndex
-            )}:\xa0`}</span>
-          </td>
+          <td>{variantLabel}</td>
         )}
         <LineColumns
           columns={columns}
@@ -219,21 +222,20 @@ export function ChapterViewLineVariant({
           isInLineGroup={true}
         />
       </>
-    ),
-    [
-      variant.isPrimaryVariant,
-      variant.originalIndex,
-      line,
-      activeLine,
-      showOldLineNumbers,
-      expandLineLinks,
-      chapter.url,
-      columns,
-      maxColumns,
-      showMeter,
-      showIpa,
-    ]
-  )
+    )
+  }, [
+    variant.isPrimaryVariant,
+    variant.originalIndex,
+    line,
+    activeLine,
+    showOldLineNumbers,
+    expandLineLinks,
+    chapter.url,
+    columns,
+    maxColumns,
+    showMeter,
+    showIpa,
+  ])
   const score = useMemo(
     () => (
       <CollapsibleRow show={showScore} id={scoreId} totalColumns={totalColumns}>

--- a/src/corpus/ui/LineNumber.tsx
+++ b/src/corpus/ui/LineNumber.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { ReactNode, useEffect, useRef } from 'react'
 import lineNumberToString, {
   lineNumberToAtf,
 } from 'transliteration/domain/lineNumberToString'
@@ -44,11 +44,13 @@ export default function LineNumber({
   activeLine,
   showOldLineNumbers,
   url,
+  children,
 }: {
   line: LineDisplay
   activeLine: string
   showOldLineNumbers: boolean
   url?: string | null
+  children?: ReactNode
 }): JSX.Element {
   const ref = useRef<HTMLAnchorElement>(null)
   const id = lineNumberToAtf(line.number)
@@ -92,6 +94,7 @@ export default function LineNumber({
           show={showOldLineNumbers}
         />
       )}
+      {children}
     </td>
   )
 }


### PR DESCRIPTION
When only the 2nd variant matches, e.g., in https://www.ebl.lmu.de/fragmentarium/search/?transliteration=ka-li#corpus in "Literature > Poem of Creation (Enūma eliš) > Standard Babylonian I", line 61, it would display it as if it was the reconstruction, which is confusing. With this change, it shows the variant label in addition to the line number in such cases.