### PR TITLE
Add number validation

### DIFF
--- a/src/fragmentarium/ui/SearchForm.tsx
+++ b/src/fragmentarium/ui/SearchForm.tsx
@@ -109,9 +109,6 @@ class SearchForm extends Component<Props, State> {
     this.setState((prevState) => ({ ...prevState, [name]: value }))
   }
 
-  onChangePages = (value: string): void => {
-    this.setState({ pages: value })
-  }
   onChangeNumber = (value: string): void => {
     this.setState({ number: value, isValid: isValidNumber(value) })
   }
@@ -205,9 +202,7 @@ class SearchForm extends Component<Props, State> {
                 placeholder="Page"
                 aria-label="Pages"
                 value={this.state.pages || ''}
-                onChange={(event: React.ChangeEvent<HTMLInputElement>): void =>
-                  this.onChangePages(event.target.value)
-                }
+                onChange={this.onChange('pages')}
               />
             </Col>
           </Form.Group>

--- a/src/fragmentarium/ui/SearchForm.tsx
+++ b/src/fragmentarium/ui/SearchForm.tsx
@@ -46,6 +46,7 @@ interface State {
   scriptPeriod: PeriodString
   scriptPeriodModifier: PeriodModifierString
   genre: string | null
+  isValid: boolean
 }
 
 type Props = {
@@ -57,6 +58,10 @@ type Props = {
   history: History
   project?: keyof typeof ResearchProjects | null
 } & RouteComponentProps
+
+export function isValidNumber(number?: string): boolean {
+  return !number || !/^[.*]+$/.test(number.trim())
+}
 
 class SearchForm extends Component<Props, State> {
   constructor(props: Props) {
@@ -77,6 +82,7 @@ class SearchForm extends Component<Props, State> {
       scriptPeriod: fragmentQuery.scriptPeriod || '',
       scriptPeriodModifier: fragmentQuery.scriptPeriodModifier || '',
       genre: fragmentQuery.genre || '',
+      isValid: isValidNumber(fragmentQuery.number),
     }
 
     if (
@@ -106,6 +112,9 @@ class SearchForm extends Component<Props, State> {
   onChangePages = (value: string): void => {
     this.setState({ pages: value })
   }
+  onChangeNumber = (value: string): void => {
+    this.setState({ number: value, isValid: isValidNumber(value) })
+  }
 
   onChangeBibliographyReference = (event: BibliographyEntry) => {
     const newState = produce(this.state, (draftState) => {
@@ -117,7 +126,7 @@ class SearchForm extends Component<Props, State> {
 
   flattenState(state: State): FragmentQuery {
     const cleanedTransliteration = _.trimEnd(state.transliteration || '')
-    return _.omitBy(
+    const stateWithoutNull = _.omitBy(
       {
         number: state.number,
         lemmas: state.lemmas,
@@ -135,6 +144,7 @@ class SearchForm extends Component<Props, State> {
       },
       (value) => !value
     )
+    return _.omit(stateWithoutNull, 'isValid')
   }
   search = (event: React.MouseEvent<HTMLElement>) => {
     event.preventDefault()
@@ -161,8 +171,12 @@ class SearchForm extends Component<Props, State> {
                 aria-label="Number"
                 onChange={(
                   event: React.ChangeEvent<HTMLTextAreaElement>
-                ): void => this.onChange('number')(event.target.value)}
+                ): void => this.onChangeNumber(event.target.value)}
+                isInvalid={!this.state.isValid}
               />
+              <Form.Control.Feedback type="invalid">
+                At least one of prefix, number or suffix must be specified.
+              </Form.Control.Feedback>
             </Col>
           </Form.Group>
           <Form.Group as={Row} controlId="reference">
@@ -286,6 +300,7 @@ class SearchForm extends Component<Props, State> {
               className="w-25 m-1"
               onClick={this.search}
               variant="primary"
+              disabled={!this.state.isValid}
             >
               Search
             </Button>

--- a/src/fragmentarium/ui/search/FragmentariumSearch.tsx
+++ b/src/fragmentarium/ui/search/FragmentariumSearch.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import _ from 'lodash'
 import AppContent from 'common/AppContent'
 import SessionContext from 'auth/SessionContext'
-import SearchForm from 'fragmentarium/ui/SearchForm'
+import SearchForm, { isValidNumber } from 'fragmentarium/ui/SearchForm'
 import { SectionCrumb, TextCrumb } from 'common/Breadcrumbs'
 import { Session } from 'auth/Session'
 import FragmentService from 'fragmentarium/application/FragmentService'
@@ -52,7 +52,9 @@ function FragmentariumSearch({
     'transliteration'
   )
   const showResults =
-    hasNonDefaultValues(fragmentQuery) || hasNonDefaultValues(corpusQuery)
+    (isValidNumber(fragmentQuery.number) &&
+      hasNonDefaultValues(fragmentQuery)) ||
+    hasNonDefaultValues(corpusQuery)
   return (
     <AppContent
       crumbs={[new SectionCrumb('Fragmentarium'), new TextCrumb('Search')]}

--- a/src/fragmentarium/ui/search/__snapshots__/FragmentariumSearch.test.tsx.snap
+++ b/src/fragmentarium/ui/search/__snapshots__/FragmentariumSearch.test.tsx.snap
@@ -86,6 +86,11 @@ exports[`Searching fragments by transliteration Displays corpus results when cli
                   type="text"
                   value=""
                 />
+                <div
+                  class="invalid-feedback"
+                >
+                  At least one of prefix, number or suffix must be specified.
+                </div>
               </div>
             </div>
             <div


### PR DESCRIPTION
Prevent wildcard-only number queries like `*.*.*`. They result in too many matches in the API, causing MongoDB to exceed its memory limit in the search aggregation.