### PR TITLE
Add warning for unsaved changes on tab close

### DIFF
--- a/src/fragmentarium/ui/edition/TransliterationForm.test.tsx
+++ b/src/fragmentarium/ui/edition/TransliterationForm.test.tsx
@@ -1,31 +1,52 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
-import { changeValueByLabel, submitFormByTestId } from 'test-support/utils'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { submitFormByTestId } from 'test-support/utils'
 import { Promise } from 'bluebird'
 
 import TransliterationForm from './TransliterationForm'
+import { act } from 'react-dom/test-utils'
+import userEvent from '@testing-library/user-event'
 
 const transliteration = 'line1\nline2'
 const notes = 'notes'
 const introduction = 'introduction'
 
+let addEventListenerSpy
 let updateEdition
 
-beforeEach(() => {
+beforeEach(async () => {
+  jest.restoreAllMocks()
+  addEventListenerSpy = jest.spyOn(window, 'addEventListener')
   updateEdition = jest.fn()
   updateEdition.mockReturnValue(Promise.resolve())
 
-  render(
-    <TransliterationForm
-      transliteration={transliteration}
-      notes={notes}
-      introduction={introduction}
-      updateEdition={updateEdition}
-    />
-  )
+  act(() => {
+    render(
+      <TransliterationForm
+        transliteration={transliteration}
+        notes={notes}
+        introduction={introduction}
+        updateEdition={updateEdition}
+      />
+    )
+  })
 })
 
-test('Submitting the form calls updateEdition', () => {
+it('Updates transliteration on change', async () => {
+  const newTransliteration = 'line1\nline2\nnew line'
+  const transliterationEditor = screen.getAllByRole('textbox')[0]
+  fireEvent.click(transliterationEditor)
+  await userEvent.click(transliterationEditor)
+  await userEvent.paste(transliterationEditor, newTransliteration)
+  act(() => {
+    fireEvent.change(transliterationEditor, {
+      target: { value: newTransliteration },
+    })
+  })
+  expect(transliterationEditor).toHaveValue(newTransliteration)
+})
+
+it('Submitting the form calls updateEdition', () => {
   submitFormByTestId(screen, 'transliteration-form')
   expect(updateEdition).toHaveBeenCalledWith(
     transliteration,
@@ -34,45 +55,31 @@ test('Submitting the form calls updateEdition', () => {
   )
 })
 
-xit('Updates transliteration on change', () => {
+it('Displays warning before closing when unsaved', async () => {
   const newTransliteration = 'line1\nline2\nnew line'
-  changeValueByLabel(screen, 'Transliteration', newTransliteration)
-
-  expect(screen.getByLabelText('Transliteration')).toHaveValue(
-    newTransliteration
-  )
-})
-
-it('Updates introduction on change', () => {
-  const newIntroduction = 'Introduction\n\nintroduction continued'
-  changeValueByLabel(screen, 'Introduction', newIntroduction)
-
-  expect(screen.getByLabelText('Introduction')).toHaveValue(newIntroduction)
-})
-xit('Displays warning before closing when unsaved', () => {
-  const newTransliteration = 'line1\nline2\nnew line'
-  changeValueByLabel(screen, 'Transliteration', newTransliteration)
-
-  const addEventListenerSpy = jest.spyOn(window, 'addEventListener')
-
-  render(
-    <TransliterationForm
-      transliteration={newTransliteration}
-      notes={notes}
-      introduction={introduction}
-      updateEdition={updateEdition}
-    />
-  )
-
-  const event = new Event('beforeunload', { cancelable: true })
-  window.dispatchEvent(event)
-
+  window.confirm = jest.fn(() => true)
+  const beforeUnloadEvent = new Event('beforeunload', { cancelable: true })
+  const transliterationEditor = screen.getAllByRole('textbox')[0]
+  fireEvent.click(transliterationEditor)
+  await userEvent.click(transliterationEditor)
+  await userEvent.paste(transliterationEditor, newTransliteration)
+  act(() => {
+    fireEvent.change(transliterationEditor, {
+      target: { value: newTransliteration },
+    })
+  })
+  expect(transliterationEditor).toHaveValue(newTransliteration)
+  window.dispatchEvent(beforeUnloadEvent)
   expect(addEventListenerSpy).toHaveBeenCalledWith(
     'beforeunload',
     expect.any(Function)
   )
-  expect(event).toContain(
+  const mockEvent = { returnValue: '' }
+  const beforeUnloadHandler = addEventListenerSpy.mock.calls.find(
+    (call) => call[0] === 'beforeunload'
+  )[1]
+  beforeUnloadHandler(mockEvent)
+  expect(mockEvent.returnValue).toBe(
     'You have unsaved changes. Are you sure you want to leave?'
   )
-  addEventListenerSpy.mockRestore()
 })

--- a/src/fragmentarium/ui/edition/TransliterationForm.test.tsx
+++ b/src/fragmentarium/ui/edition/TransliterationForm.test.tsx
@@ -43,9 +43,36 @@ xit('Updates transliteration on change', () => {
   )
 })
 
-xit('Updates introduction on change', () => {
+it('Updates introduction on change', () => {
   const newIntroduction = 'Introduction\n\nintroduction continued'
   changeValueByLabel(screen, 'Introduction', newIntroduction)
 
   expect(screen.getByLabelText('Introduction')).toHaveValue(newIntroduction)
+})
+xit('Displays warning before closing when unsaved', () => {
+  const newTransliteration = 'line1\nline2\nnew line'
+  changeValueByLabel(screen, 'Transliteration', newTransliteration)
+
+  const addEventListenerSpy = jest.spyOn(window, 'addEventListener')
+
+  render(
+    <TransliterationForm
+      transliteration={newTransliteration}
+      notes={notes}
+      introduction={introduction}
+      updateEdition={updateEdition}
+    />
+  )
+
+  const event = new Event('beforeunload', { cancelable: true })
+  window.dispatchEvent(event)
+
+  expect(addEventListenerSpy).toHaveBeenCalledWith(
+    'beforeunload',
+    expect.any(Function)
+  )
+  expect(event).toContain(
+    'You have unsaved changes. Are you sure you want to leave?'
+  )
+  addEventListenerSpy.mockRestore()
 })

--- a/src/fragmentarium/ui/edition/TransliterationForm.tsx
+++ b/src/fragmentarium/ui/edition/TransliterationForm.tsx
@@ -55,8 +55,34 @@ class TransliterationForm extends Component<Props, State> {
     this.updatePromise = Promise.resolve()
   }
 
+  componentDidMount(): void {
+    this.setupBeforeUnloadListener()
+  }
+  componentDidUpdate(prevProps: Props, prevState: State): void {
+    if (
+      this.hasChanges !==
+      (prevState.transliteration !== prevProps.transliteration ||
+        prevState.notes !== prevProps.notes ||
+        prevState.introduction !== prevProps.introduction)
+    ) {
+      this.setupBeforeUnloadListener()
+    }
+  }
   componentWillUnmount(): void {
+    window.removeEventListener('beforeunload', this.handleBeforeUnload)
     this.updatePromise.cancel()
+  }
+  setupBeforeUnloadListener = (): void => {
+    window.removeEventListener('beforeunload', this.handleBeforeUnload)
+    if (this.hasChanges) {
+      window.addEventListener('beforeunload', this.handleBeforeUnload)
+    }
+  }
+  handleBeforeUnload = (e: BeforeUnloadEvent): string => {
+    const confirmationMessage =
+      'You have unsaved changes. Are you sure you want to leave?'
+    e.returnValue = confirmationMessage // Standard for most browsers
+    return confirmationMessage // For some older browsers
   }
 
   get hasChanges(): boolean {

--- a/src/fragmentarium/ui/edition/TransliterationForm.tsx
+++ b/src/fragmentarium/ui/edition/TransliterationForm.tsx
@@ -81,8 +81,8 @@ class TransliterationForm extends Component<Props, State> {
   handleBeforeUnload = (e: BeforeUnloadEvent): string => {
     const confirmationMessage =
       'You have unsaved changes. Are you sure you want to leave?'
-    e.returnValue = confirmationMessage // Standard for most browsers
-    return confirmationMessage // For some older browsers
+    e.returnValue = confirmationMessage
+    return confirmationMessage
   }
 
   get hasChanges(): boolean {


### PR DESCRIPTION
Add warning for unsaved changes on tab close

Implement a beforeunload event listener in TransliterationForm. This update adds a warning message when the user tries to close the tab if there are unsaved changes. 