### PR TITLE
Filter Indirect Joins

### DIFF
--- a/src/corpus/ui/Chapters.tsx
+++ b/src/corpus/ui/Chapters.tsx
@@ -70,20 +70,6 @@ function excludeIndirectJoins(manuscripts: Manuscript[]): Manuscript[] {
   )
 }
 
-function ColumnTitle({
-  id,
-  children,
-}: {
-  id: string
-  children: ReactNode
-}): JSX.Element {
-  return (
-    <th id={id} scope="col" className="list-of-manuscripts__column-heading">
-      {children}
-    </th>
-  )
-}
-
 const Manuscripts = withData<
   {
     uncertainFragments: readonly UncertainFragment[]
@@ -118,12 +104,26 @@ const Manuscripts = withData<
         <colgroup span={3}></colgroup>
         <thead>
           <tr className="list-of-manuscripts__header">
-            <ColumnTitle id={siglumId}>Siglum</ColumnTitle>
-            <ColumnTitle id={museumNumberId}>
+            <th
+              id={siglumId}
+              scope="col"
+              className="list-of-manuscripts__column-heading"
+            >
+              Siglum
+            </th>
+            <th
+              id={museumNumberId}
+              scope="col"
+              className="list-of-manuscripts__column-heading"
+            >
               Museum Number
               <ReferencesHelp className="list-of-manuscripts__help" />
-            </ColumnTitle>
-            <ColumnTitle id={extantLinesId}>
+            </th>
+            <th
+              id={extantLinesId}
+              scope="col"
+              className="list-of-manuscripts__column-heading"
+            >
               Extant Lines
               <span className="list-of-manuscripts__help">
                 <HelpTrigger
@@ -137,7 +137,7 @@ const Manuscripts = withData<
                   }
                 />
               </span>
-            </ColumnTitle>
+            </th>
           </tr>
         </thead>
         <tbody>

--- a/src/corpus/ui/Chapters.tsx
+++ b/src/corpus/ui/Chapters.tsx
@@ -70,6 +70,20 @@ function excludeIndirectJoins(manuscripts: Manuscript[]): Manuscript[] {
   )
 }
 
+function ColumnTitle({
+  id,
+  children,
+}: {
+  id: string
+  children: ReactNode
+}): JSX.Element {
+  return (
+    <th id={id} scope="col" className="list-of-manuscripts__column-heading">
+      {children}
+    </th>
+  )
+}
+
 const Manuscripts = withData<
   {
     uncertainFragments: readonly UncertainFragment[]
@@ -104,26 +118,12 @@ const Manuscripts = withData<
         <colgroup span={3}></colgroup>
         <thead>
           <tr className="list-of-manuscripts__header">
-            <th
-              id={siglumId}
-              scope="col"
-              className="list-of-manuscripts__column-heading"
-            >
-              Siglum
-            </th>
-            <th
-              id={museumNumberId}
-              scope="col"
-              className="list-of-manuscripts__column-heading"
-            >
+            <ColumnTitle id={siglumId}>Siglum</ColumnTitle>
+            <ColumnTitle id={museumNumberId}>
               Museum Number
               <ReferencesHelp className="list-of-manuscripts__help" />
-            </th>
-            <th
-              id={extantLinesId}
-              scope="col"
-              className="list-of-manuscripts__column-heading"
-            >
+            </ColumnTitle>
+            <ColumnTitle id={extantLinesId}>
               Extant Lines
               <span className="list-of-manuscripts__help">
                 <HelpTrigger
@@ -137,7 +137,7 @@ const Manuscripts = withData<
                   }
                 />
               </span>
-            </th>
+            </ColumnTitle>
           </tr>
         </thead>
         <tbody>

--- a/src/corpus/ui/Chapters.tsx
+++ b/src/corpus/ui/Chapters.tsx
@@ -18,6 +18,8 @@ import { ChapterId } from 'transliteration/domain/chapter-id'
 import './Chapters.sass'
 import ManuscriptJoins from './ManuscriptJoins'
 import ManuscriptReferences from './ManuscriptReferences'
+import produce, { castDraft } from 'immer'
+import { Join } from 'fragmentarium/domain/join'
 
 function ProvenanceHeading({
   id,
@@ -37,6 +39,40 @@ function ProvenanceHeading({
         {children}
       </th>
     </tr>
+  )
+}
+
+function excludeIndirectJoins(manuscripts: Manuscript[]): Manuscript[] {
+  type JoinGroup = readonly Join[]
+  const flatJoins = _.flatMap(manuscripts, 'joins')
+  const seenJoins: JoinGroup[] = []
+  const duplicateJoinGroups: JoinGroup[] = []
+
+  flatJoins.forEach((join) => {
+    if (_.some(seenJoins, (o) => _.isEqual(o, join))) {
+      duplicateJoinGroups.push(join)
+    } else {
+      seenJoins.push(join)
+    }
+  })
+
+  function isUniqueJoin(other: JoinGroup): boolean {
+    return !_.some(duplicateJoinGroups, (group) => _.isEqual(group, other))
+  }
+
+  return manuscripts.map((manuscript) =>
+    produce(manuscript, (draft) => {
+      function isPrimaryJoin(joins: JoinGroup): boolean {
+        return _.some(
+          joins.map((join) => join.museumNumber === manuscript.museumNumber)
+        )
+      }
+      draft.joins = castDraft(
+        manuscript.joins.filter(
+          (joinGroup) => isPrimaryJoin(joinGroup) || isUniqueJoin(joinGroup)
+        )
+      )
+    })
   )
 }
 
@@ -121,46 +157,50 @@ const Manuscripts = withData<
                   <ProvenanceHeading id={provenanceId}>
                     {provenance}
                   </ProvenanceHeading>
-                  {manuscripts.map((manuscript, index) => {
-                    const rowId = _.uniqueId('row-')
-                    return (
-                      <tr key={`${provenance} ${index}`}>
-                        <th
-                          id={rowId}
-                          headers={[provenanceId, siglumId].join(' ')}
-                          scope="row"
-                          className="list-of-manuscripts__siglum-heading"
-                        >
-                          {manuscript.siglum}
-                        </th>
-                        <td
-                          headers={[provenanceId, rowId, museumNumberId].join(
-                            ' '
-                          )}
-                          className="list-of-manuscripts__museum-numbers"
-                        >
-                          <ManuscriptJoins manuscript={manuscript} />
-                          <ManuscriptReferences
-                            references={manuscript.references}
-                          />
-                        </td>
-                        <td
-                          headers={[extantLinesId, rowId, museumNumberId].join(
-                            ' '
-                          )}
-                          className="list-of-manuscripts__extant-lines"
-                        >
-                          {extantLines ? (
-                            <ExtantLinesList
-                              extantLines={extantLines[manuscript.siglum]}
+                  {excludeIndirectJoins(manuscripts).map(
+                    (manuscript, index) => {
+                      const rowId = _.uniqueId('row-')
+                      return (
+                        <tr key={`${provenance} ${index}`}>
+                          <th
+                            id={rowId}
+                            headers={[provenanceId, siglumId].join(' ')}
+                            scope="row"
+                            className="list-of-manuscripts__siglum-heading"
+                          >
+                            {manuscript.siglum}
+                          </th>
+                          <td
+                            headers={[provenanceId, rowId, museumNumberId].join(
+                              ' '
+                            )}
+                            className="list-of-manuscripts__museum-numbers"
+                          >
+                            <ManuscriptJoins manuscript={manuscript} />
+                            <ManuscriptReferences
+                              references={manuscript.references}
                             />
-                          ) : (
-                            <Spinner />
-                          )}
-                        </td>
-                      </tr>
-                    )
-                  })}
+                          </td>
+                          <td
+                            headers={[
+                              extantLinesId,
+                              rowId,
+                              museumNumberId,
+                            ].join(' ')}
+                            className="list-of-manuscripts__extant-lines"
+                          >
+                            {extantLines ? (
+                              <ExtantLinesList
+                                extantLines={extantLines[manuscript.siglum]}
+                              />
+                            ) : (
+                              <Spinner />
+                            )}
+                          </td>
+                        </tr>
+                      )
+                    }
+                  )}
                 </React.Fragment>
               )
             })

--- a/src/corpus/ui/Chapters.tsx
+++ b/src/corpus/ui/Chapters.tsx
@@ -44,20 +44,14 @@ function ProvenanceHeading({
 
 function excludeIndirectJoins(manuscripts: Manuscript[]): Manuscript[] {
   type JoinGroup = readonly Join[]
-  const flatJoins = _.flatMap(manuscripts, 'joins')
-  const seenJoins: JoinGroup[] = []
-  const duplicateJoinGroups: JoinGroup[] = []
-
-  flatJoins.forEach((join) => {
-    if (_.some(seenJoins, (o) => _.isEqual(o, join))) {
-      duplicateJoinGroups.push(join)
-    } else {
-      seenJoins.push(join)
-    }
-  })
+  const uniqueJoinGroups: JoinGroup[] = _(manuscripts)
+    .flatMap('joins')
+    .map((join) => [join])
+    .thru((values) => _.xorWith(...(values as [JoinGroup[]]), _.isEqual))
+    .value()
 
   function isUniqueJoin(other: JoinGroup): boolean {
-    return !_.some(duplicateJoinGroups, (group) => _.isEqual(group, other))
+    return _.some(uniqueJoinGroups, (group) => _.isEqual(group, other))
   }
 
   return manuscripts.map((manuscript) =>


### PR DESCRIPTION
Implements the `excludeIndirectJoins` function that filters manuscripts passed to the `Manuscripts` component for display such that indirect joins are excluded. They should only be displayed if 
1. they contain the manuscript museum number they are associated with or
2. they are not listed anywhere else in the group.

1. is trivial but 2. requires all join groups to be collected in order to check for uniqueness.