### PR TITLE
Fix 500 Error when Saving Repeatedly

### DIFF
--- a/src/fragmentarium/application/FragmentService.test.ts
+++ b/src/fragmentarium/application/FragmentService.test.ts
@@ -54,7 +54,6 @@ const word: Word = wordFactory.build()
 const fragmentRepository = {
   statistics: jest.fn(),
   find: jest.fn(),
-  updateTransliteration: jest.fn(),
   updateLemmatization: jest.fn(),
   updateGenres: jest.fn(),
   updateScript: jest.fn(),
@@ -271,27 +270,6 @@ describe('methods returning fragment', () => {
         "You don't have permissions to view this fragment."
       )
     })
-  })
-
-  describe('update transliteration', () => {
-    const transliteration = '1. kur'
-
-    beforeEach(async () => {
-      fragmentRepository.updateTransliteration.mockReturnValue(
-        Promise.resolve(fragment)
-      )
-      result = await fragmentService.updateTransliteration(
-        fragment.number,
-        transliteration
-      )
-    })
-
-    test('Returns updated fragment', () => expect(result).toEqual(fragment))
-    test('Finds correct fragment', () =>
-      expect(fragmentRepository.updateTransliteration).toHaveBeenCalledWith(
-        fragment.number,
-        transliteration
-      ))
   })
 
   describe('update edition', () => {

--- a/src/fragmentarium/application/FragmentService.test.ts
+++ b/src/fragmentarium/application/FragmentService.test.ts
@@ -55,7 +55,6 @@ const fragmentRepository = {
   statistics: jest.fn(),
   find: jest.fn(),
   updateTransliteration: jest.fn(),
-  updateIntroduction: jest.fn(),
   updateLemmatization: jest.fn(),
   updateGenres: jest.fn(),
   updateScript: jest.fn(),
@@ -294,26 +293,6 @@ describe('methods returning fragment', () => {
         transliteration
       ))
   })
-  describe('update introduction', () => {
-    const introduction = 'Introductory @i{text}'
-
-    beforeEach(async () => {
-      fragmentRepository.updateIntroduction.mockReturnValue(
-        Promise.resolve(fragment)
-      )
-      result = await fragmentService.updateIntroduction(
-        fragment.number,
-        introduction
-      )
-    })
-
-    test('Returns updated fragment', () => expect(result).toEqual(fragment))
-    test('Finds correct fragment', () =>
-      expect(fragmentRepository.updateIntroduction).toHaveBeenCalledWith(
-        fragment.number,
-        introduction
-      ))
-  })
 
   describe('update edition', () => {
     const edition = {
@@ -323,9 +302,6 @@ describe('methods returning fragment', () => {
     }
 
     beforeEach(async () => {
-      fragmentRepository.updateIntroduction.mockReturnValue(
-        Promise.resolve(fragment)
-      )
       fragmentRepository.updateEdition.mockReturnValue(
         Promise.resolve(fragment)
       )

--- a/src/fragmentarium/application/FragmentService.test.ts
+++ b/src/fragmentarium/application/FragmentService.test.ts
@@ -331,38 +331,28 @@ describe('methods returning fragment', () => {
       ))
   })
   describe('update edition', () => {
-    const transliteration = '1. kur'
-    const notes = 'notes'
-    const introduction = 'Introductory @i{text}'
+    const edition = {
+      transliteration: '1. kur',
+      notes: 'notes',
+      introduction: 'Introductory @i{text}',
+    }
 
     beforeEach(async () => {
       fragmentRepository.updateIntroduction.mockReturnValue(
         Promise.resolve(fragment)
       )
       fragmentRepository.updateNotes.mockReturnValue(Promise.resolve(fragment))
-      fragmentRepository.updateTransliteration.mockReturnValue(
+      fragmentRepository.updateEdition.mockReturnValue(
         Promise.resolve(fragment)
       )
-      result = await fragmentService.updateEdition(fragment.number, {
-        transliteration,
-        notes,
-        introduction,
-      })
+      result = await fragmentService.updateEdition(fragment.number, edition)
     })
 
     test('Returns updated fragment', () => expect(result).toEqual(fragment))
     test('Finds correct fragment', () => {
-      expect(fragmentRepository.updateTransliteration).toHaveBeenCalledWith(
+      expect(fragmentRepository.updateEdition).toHaveBeenCalledWith(
         fragment.number,
-        transliteration
-      )
-      expect(fragmentRepository.updateIntroduction).toHaveBeenCalledWith(
-        fragment.number,
-        introduction
-      )
-      expect(fragmentRepository.updateNotes).toHaveBeenCalledWith(
-        fragment.number,
-        notes
+        edition
       )
     })
   })

--- a/src/fragmentarium/application/FragmentService.test.ts
+++ b/src/fragmentarium/application/FragmentService.test.ts
@@ -56,7 +56,6 @@ const fragmentRepository = {
   find: jest.fn(),
   updateTransliteration: jest.fn(),
   updateIntroduction: jest.fn(),
-  updateNotes: jest.fn(),
   updateLemmatization: jest.fn(),
   updateGenres: jest.fn(),
   updateScript: jest.fn(),
@@ -315,21 +314,7 @@ describe('methods returning fragment', () => {
         introduction
       ))
   })
-  describe('update notes', () => {
-    const notes = 'Notes @i{text}'
 
-    beforeEach(async () => {
-      fragmentRepository.updateNotes.mockReturnValue(Promise.resolve(fragment))
-      result = await fragmentService.updateNotes(fragment.number, notes)
-    })
-
-    test('Returns updated fragment', () => expect(result).toEqual(fragment))
-    test('Finds correct fragment', () =>
-      expect(fragmentRepository.updateNotes).toHaveBeenCalledWith(
-        fragment.number,
-        notes
-      ))
-  })
   describe('update edition', () => {
     const edition = {
       transliteration: '1. kur',
@@ -341,7 +326,6 @@ describe('methods returning fragment', () => {
       fragmentRepository.updateIntroduction.mockReturnValue(
         Promise.resolve(fragment)
       )
-      fragmentRepository.updateNotes.mockReturnValue(Promise.resolve(fragment))
       fragmentRepository.updateEdition.mockReturnValue(
         Promise.resolve(fragment)
       )

--- a/src/fragmentarium/application/FragmentService.test.ts
+++ b/src/fragmentarium/application/FragmentService.test.ts
@@ -82,6 +82,7 @@ const fragmentRepository = {
   listAllFragments: jest.fn(),
   queryByTraditionalReferences: jest.fn(),
   updateScopes: jest.fn(),
+  updateEdition: jest.fn(),
 }
 
 const imageRepository = {
@@ -342,12 +343,11 @@ describe('methods returning fragment', () => {
       fragmentRepository.updateTransliteration.mockReturnValue(
         Promise.resolve(fragment)
       )
-      result = await fragmentService.updateEdition(
-        fragment.number,
+      result = await fragmentService.updateEdition(fragment.number, {
         transliteration,
         notes,
-        introduction
-      )
+        introduction,
+      })
     })
 
     test('Returns updated fragment', () => expect(result).toEqual(fragment))

--- a/src/fragmentarium/application/FragmentService.ts
+++ b/src/fragmentarium/application/FragmentService.ts
@@ -90,7 +90,6 @@ export interface FragmentRepository {
     transliteration: string
   ): Bluebird<Fragment>
   updateIntroduction(number: string, introduction: string): Bluebird<Fragment>
-  updateNotes(number: string, notes: string): Bluebird<Fragment>
   updateEdition(number: string, updates: EditionFields): Bluebird<Fragment>
   updateLemmatization(
     number: string,
@@ -233,12 +232,6 @@ export class FragmentService {
   updateIntroduction(number: string, introduction: string): Bluebird<Fragment> {
     return this.fragmentRepository
       .updateIntroduction(number, introduction)
-      .then((fragment: Fragment) => this.injectReferences(fragment))
-  }
-
-  updateNotes(number: string, notes: string): Bluebird<Fragment> {
-    return this.fragmentRepository
-      .updateNotes(number, notes)
       .then((fragment: Fragment) => this.injectReferences(fragment))
   }
 

--- a/src/fragmentarium/application/FragmentService.ts
+++ b/src/fragmentarium/application/FragmentService.ts
@@ -85,10 +85,6 @@ export interface FragmentRepository {
     number: string,
     date: MesopotamianDate[]
   ): Bluebird<Fragment>
-  updateTransliteration(
-    number: string,
-    transliteration: string
-  ): Bluebird<Fragment>
   updateEdition(number: string, updates: EditionFields): Bluebird<Fragment>
   updateLemmatization(
     number: string,
@@ -217,15 +213,6 @@ export class FragmentService {
 
   listAllFragments(): Bluebird<string[]> {
     return this.fragmentRepository.listAllFragments()
-  }
-
-  updateTransliteration(
-    number: string,
-    transliteration: string
-  ): Bluebird<Fragment> {
-    return this.fragmentRepository
-      .updateTransliteration(number, transliteration)
-      .then((fragment: Fragment) => this.injectReferences(fragment))
   }
 
   updateEdition(number: string, updates: EditionFields): Bluebird<Fragment> {

--- a/src/fragmentarium/application/FragmentService.ts
+++ b/src/fragmentarium/application/FragmentService.ts
@@ -55,10 +55,14 @@ export interface ImageRepository {
   findThumbnail(number: string, size: ThumbnailSize): Bluebird<ThumbnailBlob>
 }
 
-export interface EditionFields {
-  readonly transliteration: string | null
-  readonly notes: string | null
-  readonly introduction: string | null
+export const editionFields = [
+  'transliteration',
+  'notes',
+  'introduction',
+] as const
+
+export type EditionFields = {
+  [K in typeof editionFields[number]]: string | null
 }
 
 export interface FragmentRepository {

--- a/src/fragmentarium/application/FragmentService.ts
+++ b/src/fragmentarium/application/FragmentService.ts
@@ -89,7 +89,6 @@ export interface FragmentRepository {
     number: string,
     transliteration: string
   ): Bluebird<Fragment>
-  updateIntroduction(number: string, introduction: string): Bluebird<Fragment>
   updateEdition(number: string, updates: EditionFields): Bluebird<Fragment>
   updateLemmatization(
     number: string,
@@ -226,12 +225,6 @@ export class FragmentService {
   ): Bluebird<Fragment> {
     return this.fragmentRepository
       .updateTransliteration(number, transliteration)
-      .then((fragment: Fragment) => this.injectReferences(fragment))
-  }
-
-  updateIntroduction(number: string, introduction: string): Bluebird<Fragment> {
-    return this.fragmentRepository
-      .updateIntroduction(number, introduction)
       .then((fragment: Fragment) => this.injectReferences(fragment))
   }
 

--- a/src/fragmentarium/application/FragmentService.ts
+++ b/src/fragmentarium/application/FragmentService.ts
@@ -55,6 +55,12 @@ export interface ImageRepository {
   findThumbnail(number: string, size: ThumbnailSize): Bluebird<ThumbnailBlob>
 }
 
+export interface EditionFields {
+  readonly transliteration: string | null
+  readonly notes: string | null
+  readonly introduction: string | null
+}
+
 export interface FragmentRepository {
   statistics(): Bluebird<{ transliteratedFragments: number; lines: number }>
   find(
@@ -81,6 +87,7 @@ export interface FragmentRepository {
   ): Bluebird<Fragment>
   updateIntroduction(number: string, introduction: string): Bluebird<Fragment>
   updateNotes(number: string, notes: string): Bluebird<Fragment>
+  updateEdition(number: string, updates: EditionFields): Bluebird<Fragment>
   updateLemmatization(
     number: string,
     lemmatization: LemmatizationDto
@@ -231,22 +238,10 @@ export class FragmentService {
       .then((fragment: Fragment) => this.injectReferences(fragment))
   }
 
-  updateEdition(
-    number: string,
-    transliteration: string,
-    notes: string,
-    introduction: string
-  ): Bluebird<Fragment> {
-    return Bluebird.all([
-      this.updateTransliteration(number, transliteration),
-      this.updateIntroduction(number, introduction),
-      this.updateNotes(number, notes),
-    ]).then(([fragment, { introduction }, { notes }]) =>
-      produce(fragment, (draft) => {
-        draft.introduction = castDraft(introduction)
-        draft.notes = castDraft(notes)
-      })
-    )
+  updateEdition(number: string, updates: EditionFields): Bluebird<Fragment> {
+    return this.fragmentRepository
+      .updateEdition(number, updates)
+      .then((fragment: Fragment) => this.injectReferences(fragment))
   }
 
   updateLemmatization(

--- a/src/fragmentarium/infrastructure/FragmentRepository.test.ts
+++ b/src/fragmentarium/infrastructure/FragmentRepository.test.ts
@@ -352,14 +352,6 @@ const testData: TestData<FragmentRepository>[] = [
     Promise.resolve(fragmentDto)
   ),
   new TestData(
-    'updateNotes',
-    [fragmentId, notes],
-    apiClient.postJson,
-    fragment,
-    [`/fragments/${encodeURIComponent(fragmentId)}/notes`, { notes }],
-    Promise.resolve(fragmentDto)
-  ),
-  new TestData(
     'updateArchaeology',
     [fragmentId, archaeology],
     apiClient.postJson,

--- a/src/fragmentarium/infrastructure/FragmentRepository.test.ts
+++ b/src/fragmentarium/infrastructure/FragmentRepository.test.ts
@@ -23,6 +23,9 @@ const fragmentRepository = new FragmentRepository(apiClient)
 
 const fragmentId = 'K 23+1234'
 const cdliNumber = 'P 1234'
+const transliteration = 'transliteration'
+const notes = 'notes'
+const introduction = 'introduction'
 const lemmatization = [[{ value: 'kur', uniqueLemma: [] }]]
 const resultStub = {}
 const folio = new Folio({ name: 'MJG', number: 'K1' })
@@ -181,6 +184,60 @@ const testData: TestData<FragmentRepository>[] = [
     [fragmentInfo],
     ['/fragments?needsRevision=true', false],
     Promise.resolve([fragmentInfoDto])
+  ),
+  new TestData(
+    'updateEdition',
+    [fragmentId, { transliteration }],
+    apiClient.postJson,
+    fragment,
+    [
+      `/fragments/${encodeURIComponent(fragmentId)}/edition`,
+      {
+        transliteration,
+      },
+    ],
+    Promise.resolve(fragmentDto)
+  ),
+  new TestData(
+    'updateEdition',
+    [fragmentId, { notes }],
+    apiClient.postJson,
+    fragment,
+    [
+      `/fragments/${encodeURIComponent(fragmentId)}/edition`,
+      {
+        notes,
+      },
+    ],
+    Promise.resolve(fragmentDto)
+  ),
+  new TestData(
+    'updateEdition',
+    [fragmentId, { introduction }],
+    apiClient.postJson,
+    fragment,
+    [
+      `/fragments/${encodeURIComponent(fragmentId)}/edition`,
+      {
+        introduction,
+      },
+    ],
+    Promise.resolve(fragmentDto)
+  ),
+  new TestData(
+    'updateEdition',
+    [fragmentId, { introduction, notes, transliteration }],
+    apiClient.postJson,
+    fragment,
+    [
+      `/fragments/${encodeURIComponent(fragmentId)}/edition`,
+      {
+        introduction,
+        notes,
+        transliteration,
+      },
+    ],
+    Promise.resolve(fragmentDto)
   ),
   new TestData(
     'updateLemmatization',

--- a/src/fragmentarium/infrastructure/FragmentRepository.test.ts
+++ b/src/fragmentarium/infrastructure/FragmentRepository.test.ts
@@ -23,9 +23,7 @@ const fragmentRepository = new FragmentRepository(apiClient)
 
 const fragmentId = 'K 23+1234'
 const cdliNumber = 'P 1234'
-const transliteration = 'transliteration'
 const lemmatization = [[{ value: 'kur', uniqueLemma: [] }]]
-const notes = 'notes'
 const resultStub = {}
 const folio = new Folio({ name: 'MJG', number: 'K1' })
 const word = 'šim'
@@ -183,19 +181,6 @@ const testData: TestData<FragmentRepository>[] = [
     [fragmentInfo],
     ['/fragments?needsRevision=true', false],
     Promise.resolve([fragmentInfoDto])
-  ),
-  new TestData(
-    'updateTransliteration',
-    [fragmentId, transliteration, notes],
-    apiClient.postJson,
-    fragment,
-    [
-      `/fragments/${encodeURIComponent(fragmentId)}/transliteration`,
-      {
-        transliteration,
-      },
-    ],
-    Promise.resolve(fragmentDto)
   ),
   new TestData(
     'updateLemmatization',

--- a/src/fragmentarium/infrastructure/FragmentRepository.test.ts
+++ b/src/fragmentarium/infrastructure/FragmentRepository.test.ts
@@ -29,7 +29,6 @@ const notes = 'notes'
 const resultStub = {}
 const folio = new Folio({ name: 'MJG', number: 'K1' })
 const word = 'šim'
-const introduction = 'Introduction'
 const lemmas = 'foo I+bar II'
 const genres: Genre[] = [
   new Genre(['ARCHIVE', 'Letter'], false),
@@ -309,17 +308,6 @@ const testData: TestData<FragmentRepository>[] = [
       { fragmentNumber: fragmentId, annotations: annotationsDto },
     ],
     Promise.resolve(annotations)
-  ),
-  new TestData(
-    'updateIntroduction',
-    [fragmentId, introduction],
-    apiClient.postJson,
-    fragment,
-    [
-      `/fragments/${encodeURIComponent(fragmentId)}/introduction`,
-      { introduction },
-    ],
-    Promise.resolve(fragmentDto)
   ),
   new TestData(
     'updateGenres',

--- a/src/fragmentarium/infrastructure/FragmentRepository.ts
+++ b/src/fragmentarium/infrastructure/FragmentRepository.ts
@@ -280,15 +280,6 @@ class ApiFragmentRepository
       .then(createFragment)
   }
 
-  updateNotes(number: string, notes: string): Promise<Fragment> {
-    const path = createFragmentPath(number, 'notes')
-    return this.apiClient
-      .postJson(path, {
-        notes: notes,
-      })
-      .then(createFragment)
-  }
-
   updateEdition(number: string, updates: EditionFields): Promise<Fragment> {
     const path = createFragmentPath(number, 'edition')
     return this.apiClient

--- a/src/fragmentarium/infrastructure/FragmentRepository.ts
+++ b/src/fragmentarium/infrastructure/FragmentRepository.ts
@@ -15,6 +15,7 @@ import { Museums, MuseumKey } from 'fragmentarium/domain/museum'
 import {
   AnnotationRepository,
   CdliInfo,
+  EditionFields,
   FragmentRepository,
 } from 'fragmentarium/application/FragmentService'
 import Annotation from 'fragmentarium/domain/annotation'
@@ -285,6 +286,13 @@ class ApiFragmentRepository
       .postJson(path, {
         notes: notes,
       })
+      .then(createFragment)
+  }
+
+  updateEdition(number: string, updates: EditionFields): Promise<Fragment> {
+    const path = createFragmentPath(number, 'edition')
+    return this.apiClient
+      .postJson(path, _.omitBy(updates, _.isNull))
       .then(createFragment)
   }
 

--- a/src/fragmentarium/infrastructure/FragmentRepository.ts
+++ b/src/fragmentarium/infrastructure/FragmentRepository.ts
@@ -259,18 +259,6 @@ class ApiFragmentRepository
     return this.apiClient.postJson(path, { datesInText }).then(createFragment)
   }
 
-  updateTransliteration(
-    number: string,
-    transliteration: string
-  ): Promise<Fragment> {
-    const path = createFragmentPath(number, 'transliteration')
-    return this.apiClient
-      .postJson(path, {
-        transliteration: transliteration,
-      })
-      .then(createFragment)
-  }
-
   updateEdition(number: string, updates: EditionFields): Promise<Fragment> {
     const path = createFragmentPath(number, 'edition')
     return this.apiClient

--- a/src/fragmentarium/infrastructure/FragmentRepository.ts
+++ b/src/fragmentarium/infrastructure/FragmentRepository.ts
@@ -271,15 +271,6 @@ class ApiFragmentRepository
       .then(createFragment)
   }
 
-  updateIntroduction(number: string, introduction: string): Promise<Fragment> {
-    const path = createFragmentPath(number, 'introduction')
-    return this.apiClient
-      .postJson(path, {
-        introduction: introduction,
-      })
-      .then(createFragment)
-  }
-
   updateEdition(number: string, updates: EditionFields): Promise<Fragment> {
     const path = createFragmentPath(number, 'edition')
     return this.apiClient

--- a/src/fragmentarium/ui/edition/Edition.tsx
+++ b/src/fragmentarium/ui/edition/Edition.tsx
@@ -7,14 +7,11 @@ import './Edition.css'
 import TransliterationHeader from 'fragmentarium/ui/fragment/TransliterationHeader'
 import { Fragment } from 'fragmentarium/domain/fragment'
 import FragmentSearchService from 'fragmentarium/application/FragmentSearchService'
+import { EditionFields } from 'fragmentarium/application/FragmentService'
 
 type Props = {
   fragment: Fragment
-  updateEdition: (
-    transliteration: string,
-    notes: string,
-    introduction: string
-  ) => Bluebird<Fragment>
+  updateEdition: (fields: EditionFields) => Bluebird<Fragment>
   fragmentSearchService: FragmentSearchService
   disabled: boolean
   onToggle

--- a/src/fragmentarium/ui/edition/TransliterationForm.test.tsx
+++ b/src/fragmentarium/ui/edition/TransliterationForm.test.tsx
@@ -46,13 +46,9 @@ it('Updates transliteration on change', async () => {
   expect(transliterationEditor).toHaveValue(newTransliteration)
 })
 
-it('Submitting the form calls updateEdition', () => {
+it('calls updateEdition when submitting the form', () => {
   submitFormByTestId(screen, 'transliteration-form')
-  expect(updateEdition).toHaveBeenCalledWith(
-    transliteration,
-    notes,
-    introduction
-  )
+  expect(updateEdition).toHaveBeenCalledWith({})
 })
 
 it('Displays warning before closing when unsaved', async () => {

--- a/src/fragmentarium/ui/edition/TransliterationForm.test.tsx
+++ b/src/fragmentarium/ui/edition/TransliterationForm.test.tsx
@@ -20,7 +20,7 @@ beforeEach(async () => {
   updateEdition = jest.fn()
   updateEdition.mockReturnValue(Promise.resolve())
 
-  act(() => {
+  await act(async () => {
     render(
       <TransliterationForm
         transliteration={transliteration}
@@ -35,19 +35,23 @@ beforeEach(async () => {
 it('Updates transliteration on change', async () => {
   const newTransliteration = 'line1\nline2\nnew line'
   const transliterationEditor = screen.getAllByRole('textbox')[0]
-  fireEvent.click(transliterationEditor)
-  await userEvent.click(transliterationEditor)
-  await userEvent.paste(transliterationEditor, newTransliteration)
-  act(() => {
+
+  await act(async () => {
+    fireEvent.click(transliterationEditor)
+    await userEvent.click(transliterationEditor)
+    await userEvent.paste(transliterationEditor, newTransliteration)
     fireEvent.change(transliterationEditor, {
       target: { value: newTransliteration },
     })
   })
+
   expect(transliterationEditor).toHaveValue(newTransliteration)
 })
 
-it('calls updateEdition when submitting the form', () => {
-  submitFormByTestId(screen, 'transliteration-form')
+it('calls updateEdition when submitting the form', async () => {
+  await act(async () => {
+    submitFormByTestId(screen, 'transliteration-form')
+  })
   expect(updateEdition).toHaveBeenCalledWith({})
 })
 
@@ -56,25 +60,36 @@ it('Displays warning before closing when unsaved', async () => {
   window.confirm = jest.fn(() => true)
   const beforeUnloadEvent = new Event('beforeunload', { cancelable: true })
   const transliterationEditor = screen.getAllByRole('textbox')[0]
-  fireEvent.click(transliterationEditor)
-  await userEvent.click(transliterationEditor)
-  await userEvent.paste(transliterationEditor, newTransliteration)
-  act(() => {
+
+  await act(async () => {
+    fireEvent.click(transliterationEditor)
+    await userEvent.click(transliterationEditor)
+    await userEvent.paste(transliterationEditor, newTransliteration)
     fireEvent.change(transliterationEditor, {
       target: { value: newTransliteration },
     })
   })
+
   expect(transliterationEditor).toHaveValue(newTransliteration)
-  window.dispatchEvent(beforeUnloadEvent)
+
+  await act(async () => {
+    window.dispatchEvent(beforeUnloadEvent)
+  })
+
   expect(addEventListenerSpy).toHaveBeenCalledWith(
     'beforeunload',
     expect.any(Function)
   )
+
   const mockEvent = { returnValue: '' }
   const beforeUnloadHandler = addEventListenerSpy.mock.calls.find(
     (call) => call[0] === 'beforeunload'
   )[1]
-  beforeUnloadHandler(mockEvent)
+
+  await act(async () => {
+    beforeUnloadHandler(mockEvent)
+  })
+
   expect(mockEvent.returnValue).toBe(
     'You have unsaved changes. Are you sure you want to leave?'
   )

--- a/src/fragmentarium/ui/edition/TransliterationForm.tsx
+++ b/src/fragmentarium/ui/edition/TransliterationForm.tsx
@@ -146,11 +146,10 @@ const TransliterationForm: React.FC<Props> = ({
     [transliteration, notes, introduction]
   )
 
-  const isDirty = useCallback(
-    (field: typeof editionFields[number]): boolean =>
-      formData[field] !== initialValues[field],
-    [formData, initialValues]
-  )
+  const isDirty = (
+    _value: unknown,
+    field: typeof editionFields[number]
+  ): boolean => formData[field] !== initialValues[field]
 
   const update = (property: keyof FormData) => (value: string) => {
     setFormData({

--- a/src/fragmentarium/ui/fragment/CuneiformFragmentEditor.tsx
+++ b/src/fragmentarium/ui/fragment/CuneiformFragmentEditor.tsx
@@ -12,7 +12,9 @@ import serializeReference from 'bibliography/application/serializeReference'
 import './CuneiformFragment.sass'
 import { Fragment } from 'fragmentarium/domain/fragment'
 import WordService from 'dictionary/application/WordService'
-import FragmentService from 'fragmentarium/application/FragmentService'
+import FragmentService, {
+  EditionFields,
+} from 'fragmentarium/application/FragmentService'
 import ErrorBoundary from 'common/ErrorBoundary'
 import ArchaeologyEditor from 'fragmentarium/ui/fragment/ArchaeologyEditor'
 import { ArchaeologyDto } from 'fragmentarium/domain/archaeologyDtos'
@@ -166,18 +168,9 @@ function DisplayContents(props: TabsProps): JSX.Element {
 }
 
 function EditionContents(props: TabsProps): JSX.Element {
-  const updateEdition = (
-    transliteration: string,
-    notes: string,
-    introduction: string
-  ) =>
+  const updateEdition = (fields: EditionFields) =>
     props.onSave(
-      props.fragmentService.updateEdition(
-        props.fragment.number,
-        transliteration,
-        notes,
-        introduction
-      )
+      props.fragmentService.updateEdition(props.fragment.number, fields)
     )
   return <Edition updateEdition={updateEdition} {...props} />
 }


### PR DESCRIPTION
Saving multiple times within a short period of time causes 500 errors due to rate limits of auth0. This is caused by the fact that saving editions performs 3 separate authentication calls to /userinfo, one for the `notes`, the `introduction`, and the `transliteration`, even if no changes were made. This PR adds a dedicated /edition endpoint to handle changes to these fields with a single API call, thus mitigating the rate limit issue.

