### PR TITLE
Fix Token Display Bugs

### DIFF
--- a/src/corpus/ui/ChapterViewLine.tsx
+++ b/src/corpus/ui/ChapterViewLine.tsx
@@ -22,8 +22,7 @@ import LineNumber from './LineNumber'
 import { LineGroup, LineInfo } from 'transliteration/ui/LineGroup'
 import { AlignmentPopover } from 'transliteration/ui/WordInfo'
 import { Token } from 'transliteration/domain/token'
-import { isAkkadianWord, isBreak } from 'transliteration/domain/type-guards'
-import AkkadianWordAnalysis from 'akkadian/ui/akkadianWordAnalysis'
+import { isBreak } from 'transliteration/domain/type-guards'
 
 const lineNumberColumns = 1
 const toggleColumns = 3
@@ -211,15 +210,13 @@ export function ChapterViewLineVariant({
       token: Token
     }>): JSX.Element => {
       return (
-        <AlignmentPopover token={token} lineGroup={lineGroup}>
+        <AlignmentPopover
+          token={token}
+          lineGroup={lineGroup}
+          showMeter={showMeter}
+          showIpa={showIpa}
+        >
           {children}
-          {isAkkadianWord(token) && (
-            <AkkadianWordAnalysis
-              word={token}
-              showMeter={showMeter}
-              showIpa={showIpa}
-            />
-          )}
         </AlignmentPopover>
       )
     }

--- a/src/corpus/ui/__snapshots__/ChapterView.integration.test.ts.snap
+++ b/src/corpus/ui/__snapshots__/ChapterView.integration.test.ts.snap
@@ -4347,11 +4347,6 @@ exports[`Display chapter Sidebar 2`] = `
                       />
                     </span>
                   </span>
-                  <span
-                    class="meter-display"
-                  >
-                     
-                  </span>
                 </td>
                 <td
                   class="chapter-display__toggle"
@@ -4556,11 +4551,6 @@ exports[`Display chapter Sidebar 2`] = `
                         class="Transliteration__flag"
                       />
                     </span>
-                  </span>
-                  <span
-                    class="meter-display"
-                  >
-                     
                   </span>
                 </td>
                 <td
@@ -5352,11 +5342,6 @@ exports[`Display chapter Sidebar 3`] = `
                       />
                     </span>
                   </span>
-                  <span
-                    class="meter-display"
-                  >
-                     
-                  </span>
                 </td>
                 <td
                   class="chapter-display__toggle"
@@ -5583,11 +5568,6 @@ exports[`Display chapter Sidebar 3`] = `
                         class="Transliteration__flag"
                       />
                     </span>
-                  </span>
-                  <span
-                    class="meter-display"
-                  >
-                     
                   </span>
                 </td>
                 <td
@@ -6401,11 +6381,6 @@ exports[`Display chapter Sidebar 4`] = `
                       />
                     </span>
                   </span>
-                  <span
-                    class="meter-display"
-                  >
-                     
-                  </span>
                 </td>
                 <td
                   class="chapter-display__toggle"
@@ -6649,11 +6624,6 @@ exports[`Display chapter Sidebar 4`] = `
                         class="Transliteration__flag"
                       />
                     </span>
-                  </span>
-                  <span
-                    class="meter-display"
-                  >
-                     
                   </span>
                 </td>
                 <td
@@ -7484,11 +7454,6 @@ exports[`Display chapter Sidebar 5`] = `
                       />
                     </span>
                   </span>
-                  <span
-                    class="meter-display"
-                  >
-                     
-                  </span>
                 </td>
                 <td
                   class="chapter-display__toggle"
@@ -7732,11 +7697,6 @@ exports[`Display chapter Sidebar 5`] = `
                         class="Transliteration__flag"
                       />
                     </span>
-                  </span>
-                  <span
-                    class="meter-display"
-                  >
-                     
                   </span>
                 </td>
                 <td
@@ -8567,11 +8527,6 @@ exports[`Display chapter Sidebar 6`] = `
                       />
                     </span>
                   </span>
-                  <span
-                    class="meter-display"
-                  >
-                     
-                  </span>
                 </td>
                 <td
                   class="chapter-display__toggle"
@@ -8815,11 +8770,6 @@ exports[`Display chapter Sidebar 6`] = `
                         class="Transliteration__flag"
                       />
                     </span>
-                  </span>
-                  <span
-                    class="meter-display"
-                  >
-                     
                   </span>
                 </td>
                 <td

--- a/src/dictionary/ui/display/__snapshots__/WordDisplay.test.tsx.snap
+++ b/src/dictionary/ui/display/__snapshots__/WordDisplay.test.tsx.snap
@@ -1203,7 +1203,7 @@ exports[`Fetch word correctly displays word parts 1`] = `
                     </th>
                   </tr>
                   <tr
-                    class="lines-with-lemma__textline lines-with-lemma__textline--reconstruction"
+                    class="lines-with-lemma__textline hide-meter"
                   >
                     <td
                       class="lines-with-lemma__line-number"
@@ -1290,7 +1290,7 @@ exports[`Fetch word correctly displays word parts 1`] = `
                     </th>
                   </tr>
                   <tr
-                    class="lines-with-lemma__textline lines-with-lemma__textline--reconstruction"
+                    class="lines-with-lemma__textline hide-meter"
                   >
                     <td
                       class="lines-with-lemma__line-number"
@@ -1377,7 +1377,7 @@ exports[`Fetch word correctly displays word parts 1`] = `
                     </th>
                   </tr>
                   <tr
-                    class="lines-with-lemma__textline lines-with-lemma__textline--reconstruction"
+                    class="lines-with-lemma__textline hide-meter"
                   >
                     <td
                       class="lines-with-lemma__line-number"
@@ -1464,7 +1464,7 @@ exports[`Fetch word correctly displays word parts 1`] = `
                     </th>
                   </tr>
                   <tr
-                    class="lines-with-lemma__textline lines-with-lemma__textline--reconstruction"
+                    class="lines-with-lemma__textline hide-meter"
                   >
                     <td
                       class="lines-with-lemma__line-number"
@@ -1569,7 +1569,7 @@ exports[`Fetch word correctly displays word parts 1`] = `
                     </th>
                   </tr>
                   <tr
-                    class="lines-with-lemma__textline lines-with-lemma__textline--reconstruction"
+                    class="lines-with-lemma__textline hide-meter"
                   >
                     <td
                       class="lines-with-lemma__line-number"
@@ -1656,7 +1656,7 @@ exports[`Fetch word correctly displays word parts 1`] = `
                     </th>
                   </tr>
                   <tr
-                    class="lines-with-lemma__textline lines-with-lemma__textline--reconstruction"
+                    class="lines-with-lemma__textline hide-meter"
                   >
                     <td
                       class="lines-with-lemma__line-number"
@@ -1734,7 +1734,7 @@ exports[`Fetch word correctly displays word parts 1`] = `
                     </th>
                   </tr>
                   <tr
-                    class="lines-with-lemma__textline lines-with-lemma__textline--reconstruction"
+                    class="lines-with-lemma__textline hide-meter"
                   >
                     <td
                       class="lines-with-lemma__line-number"
@@ -1821,7 +1821,7 @@ exports[`Fetch word correctly displays word parts 1`] = `
                     </th>
                   </tr>
                   <tr
-                    class="lines-with-lemma__textline lines-with-lemma__textline--reconstruction"
+                    class="lines-with-lemma__textline hide-meter"
                   >
                     <td
                       class="lines-with-lemma__line-number"
@@ -1908,7 +1908,7 @@ exports[`Fetch word correctly displays word parts 1`] = `
                     </th>
                   </tr>
                   <tr
-                    class="lines-with-lemma__textline lines-with-lemma__textline--reconstruction"
+                    class="lines-with-lemma__textline hide-meter"
                   >
                     <td
                       class="lines-with-lemma__line-number"
@@ -1995,7 +1995,7 @@ exports[`Fetch word correctly displays word parts 1`] = `
                     </th>
                   </tr>
                   <tr
-                    class="lines-with-lemma__textline lines-with-lemma__textline--reconstruction"
+                    class="lines-with-lemma__textline hide-meter"
                   >
                     <td
                       class="lines-with-lemma__line-number"

--- a/src/dictionary/ui/search/DictionaryLineVariant.sass
+++ b/src/dictionary/ui/search/DictionaryLineVariant.sass
@@ -1,0 +1,2 @@
+.Transliteration__Caesura, .Transliteration__MetricalFootSeparator
+  display: none

--- a/src/dictionary/ui/search/DictionaryLineVariant.sass
+++ b/src/dictionary/ui/search/DictionaryLineVariant.sass
@@ -1,2 +1,3 @@
-.Transliteration__Caesura, .Transliteration__MetricalFootSeparator
-  display: none
+.lines-with-lemma__textline.hide-meter
+  .Transliteration__Caesura, .Transliteration__MetricalFootSeparator
+    display: none

--- a/src/dictionary/ui/search/DictionaryLineVariant.tsx
+++ b/src/dictionary/ui/search/DictionaryLineVariant.tsx
@@ -18,6 +18,7 @@ import { Token } from 'transliteration/domain/token'
 import { stageToAbbreviation } from 'common/period'
 import { numberToUnicodeSubscript } from 'transliteration/application/SubIndex'
 import { LemmaPopover } from 'transliteration/ui/WordInfo'
+import './DictionaryLineVariant.sass'
 
 function createCorpusChapterUrl(
   textId: TextId,

--- a/src/dictionary/ui/search/DictionaryLineVariant.tsx
+++ b/src/dictionary/ui/search/DictionaryLineVariant.tsx
@@ -19,6 +19,7 @@ import { stageToAbbreviation } from 'common/period'
 import { numberToUnicodeSubscript } from 'transliteration/application/SubIndex'
 import { LemmaPopover } from 'transliteration/ui/WordInfo'
 import './DictionaryLineVariant.sass'
+import classNames from 'classnames'
 
 function createCorpusChapterUrl(
   textId: TextId,
@@ -86,9 +87,9 @@ export default function DictionaryLineVariant({
       }}
     >
       <tr
-        className={`lines-with-lemma__textline ${
-          isVariant ? '' : 'lines-with-lemma__textline--reconstruction'
-        }`}
+        className={classNames('lines-with-lemma__textline', 'hide-meter', {
+          'lines-with-lemma__textline--reconstruction': isVariant,
+        })}
       >
         {isVariant ? (
           <td className={'lines-with-lemma__line-number--variant'}>

--- a/src/transliteration/ui/AkkadianWordAnalysis.test.tsx
+++ b/src/transliteration/ui/AkkadianWordAnalysis.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import AkkadianWordAnalysis from 'akkadian/ui/akkadianWordAnalysis'
+import { AkkadianWord } from 'transliteration/domain/token'
+
+const heavyWeight = '\uF700'
+const stressedHeavyWeight = '\uF704'
+
+const word: AkkadianWord = {
+  parts: [
+    {
+      value: 'anšar',
+      enclosureType: [],
+      cleanValue: 'anšar',
+      erasure: 'NONE',
+      type: 'ValueToken',
+    },
+  ],
+  enclosureType: [],
+  uniqueLemma: ['Anšar I'],
+  cleanValue: 'anšar',
+  hasOmittedAlignment: false,
+  modifiers: [],
+  erasure: 'NONE',
+  normalized: true,
+  alignable: true,
+  language: 'AKKADIAN',
+  value: 'anšar',
+  lemmatizable: true,
+  variant: null,
+  alignment: null,
+  hasVariantAlignment: false,
+  type: 'AkkadianWord',
+}
+
+describe('AkkadianWordAnalysis', () => {
+  it('displays meter', () => {
+    render(<AkkadianWordAnalysis word={word} showMeter={true} showIpa={true} />)
+    expect(
+      screen.getByText(`${stressedHeavyWeight} ${heavyWeight}`)
+    ).toBeInTheDocument()
+  })
+  it('displays IPA', () => {
+    render(<AkkadianWordAnalysis word={word} showMeter={true} showIpa={true} />)
+    expect(screen.getByText('ˈan.ʃar')).toBeInTheDocument()
+  })
+})

--- a/src/transliteration/ui/Transliteration.sass
+++ b/src/transliteration/ui/Transliteration.sass
@@ -182,13 +182,13 @@
       display: inline-grid
       grid-template-rows: 1fr
   .word-info__alignment-trigger
-    .word-info__trigger
-      display: inline-grid
-      grid-template-rows: 1fr
-      .meter-display
-        @include normal-font
-        color: red
+    display: inline-grid
+    grid-template-rows: 1fr
 
-      .ipa-display
-        @include normal-font
-        color: deepskyblue
+    .meter-display
+      @include normal-font
+      color: red
+
+    .ipa-display
+      @include normal-font
+      color: deepskyblue

--- a/src/transliteration/ui/WordInfo.tsx
+++ b/src/transliteration/ui/WordInfo.tsx
@@ -115,13 +115,13 @@ function AlignmentInfoPopover({
 export function AlignmentPopover({
   token,
   children,
-  showMeter,
-  showIpa,
+  showMeter = false,
+  showIpa = false,
   lineGroup,
 }: TokenActionWrapperProps & {
   lineGroup: LineGroup
-  showMeter: boolean
-  showIpa: boolean
+  showMeter?: boolean
+  showIpa?: boolean
 }): JSX.Element {
   return hasLemma(token) ? (
     <AlignmentInfoPopover

--- a/src/transliteration/ui/WordInfo.tsx
+++ b/src/transliteration/ui/WordInfo.tsx
@@ -9,10 +9,9 @@ import './WordInfo.sass'
 import { LineGroup } from './LineGroup'
 import { Alignments } from './WordInfoAlignments'
 import LemmaInfo from './WordInfoLemmas'
-import { isAnyWord } from 'transliteration/domain/type-guards'
+import { isAkkadianWord, isAnyWord } from 'transliteration/domain/type-guards'
 import { TokenActionWrapperProps } from 'transliteration/ui/LineAccumulator'
-import { OverlayChildren } from 'react-bootstrap/esm/Overlay'
-import classNames from 'classnames'
+import AkkadianWordAnalysis from 'akkadian/ui/akkadianWordAnalysis'
 
 function VariantAlignmentIndicator({
   children,
@@ -48,51 +47,17 @@ function hasLemma(token: Token): token is AnyWord {
   return isAnyWord(token) && token.uniqueLemma.length > 0
 }
 
-function WordInfoTrigger({
-  overlay,
-  children,
-  onMouseEnter,
-  onMouseLeave,
-  token,
-  className,
-}: {
-  overlay: OverlayChildren
-  children: React.ReactNode
-  token: Token
-} & Pick<
-  React.HTMLProps<HTMLSpanElement>,
-  'onMouseEnter' | 'onMouseLeave' | 'className'
->): JSX.Element {
-  return (
-    <span className={classNames('word-info__wrapper', className)}>
-      <OverlayTrigger
-        trigger="click"
-        rootClose
-        placement="top"
-        overlay={overlay}
-      >
-        <span
-          className="word-info__trigger"
-          role="button"
-          onMouseEnter={onMouseEnter}
-          onMouseLeave={onMouseLeave}
-        >
-          <VariantAlignmentIndicator token={token}>
-            {children}
-          </VariantAlignmentIndicator>
-        </span>
-      </OverlayTrigger>
-    </span>
-  )
-}
-
-export function AlignmentInfoPopover({
+function AlignmentInfoPopover({
   token,
   lineGroup,
+  showMeter,
+  showIpa,
   children,
 }: PropsWithChildren<{
   token: AnyWord
   lineGroup: LineGroup
+  showMeter: boolean
+  showIpa: boolean
 }>): JSX.Element {
   const dictionary = useDictionary()
 
@@ -116,35 +81,59 @@ export function AlignmentInfoPopover({
   )
 
   return (
-    <WordInfoTrigger
-      overlay={popover}
-      token={token}
-      onMouseEnter={() =>
-        lineGroup.setActiveTokenIndex(token.sentenceIndex || 0)
-      }
-      onMouseLeave={() => lineGroup.setActiveTokenIndex(0)}
-      className="word-info__alignment-trigger"
-    >
-      {children}
-    </WordInfoTrigger>
+    <span className={'word-info__wrapper word-info__alignment-trigger'}>
+      <OverlayTrigger
+        trigger="click"
+        rootClose
+        placement="top"
+        overlay={popover}
+      >
+        <span
+          className="word-info__trigger"
+          role="button"
+          onMouseEnter={() =>
+            lineGroup.setActiveTokenIndex(token.sentenceIndex || 0)
+          }
+          onMouseLeave={() => lineGroup.setActiveTokenIndex(0)}
+        >
+          <VariantAlignmentIndicator token={token}>
+            {children}
+          </VariantAlignmentIndicator>
+        </span>
+      </OverlayTrigger>
+      {isAkkadianWord(token) && (
+        <AkkadianWordAnalysis
+          word={token}
+          showMeter={showMeter}
+          showIpa={showIpa}
+        />
+      )}
+    </span>
   )
 }
 
 export function AlignmentPopover({
   token,
   children,
+  showMeter,
+  showIpa,
   lineGroup,
 }: TokenActionWrapperProps & {
   lineGroup: LineGroup
+  showMeter: boolean
+  showIpa: boolean
 }): JSX.Element {
   return hasLemma(token) ? (
-    <AlignmentInfoPopover token={token} lineGroup={lineGroup}>
+    <AlignmentInfoPopover
+      token={token}
+      lineGroup={lineGroup}
+      showMeter={showMeter}
+      showIpa={showIpa}
+    >
       {children}
     </AlignmentInfoPopover>
   ) : (
-    <VariantAlignmentIndicator token={token}>
-      {children}
-    </VariantAlignmentIndicator>
+    <>{children}</>
   )
 }
 
@@ -172,9 +161,20 @@ function LemmaInfoPopover({
   )
 
   return (
-    <WordInfoTrigger overlay={popover} token={token}>
-      {children}
-    </WordInfoTrigger>
+    <span className={'word-info__wrapper'}>
+      <OverlayTrigger
+        trigger="click"
+        rootClose
+        placement="top"
+        overlay={popover}
+      >
+        <span className="word-info__trigger" role="button">
+          <VariantAlignmentIndicator token={token}>
+            {children}
+          </VariantAlignmentIndicator>
+        </span>
+      </OverlayTrigger>
+    </span>
   )
 }
 


### PR DESCRIPTION
Hide meter in dictionary corpus examples and fix variant alignment indicator (`‡`) positioning