### PR TITLE
Fix Batch Lemma Annotation

### DIFF
--- a/src/fragmentarium/ui/fragment/lemma-annotation/LemmaAnnotation.tsx
+++ b/src/fragmentarium/ui/fragment/lemma-annotation/LemmaAnnotation.tsx
@@ -111,6 +111,7 @@ export default class LemmaAnnotation extends TokenAnnotation {
     )
   }
   applyToPendingInstances = (): void => {
+    this.state.activeToken?.confirmSuggestion()
     const pendingTokens = this.tokens.filter((token) => token.isPending)
     pendingTokens.forEach((token) =>
       token.updateLemmas(this.state.activeToken?.lemmas || [])

--- a/src/fragmentarium/ui/fragment/lemma-annotation/LemmaAnnotationButton.tsx
+++ b/src/fragmentarium/ui/fragment/lemma-annotation/LemmaAnnotationButton.tsx
@@ -1,6 +1,6 @@
+import EditableToken from 'fragmentarium/ui/fragment/linguistic-annotation/EditableToken'
 import React from 'react'
 import { Button, ButtonGroup, Dropdown } from 'react-bootstrap'
-import { Token } from 'transliteration/domain/token'
 import DisplayToken from 'transliteration/ui/DisplayToken'
 
 export interface LemmaActionCallbacks {
@@ -13,33 +13,26 @@ export interface LemmaActionCallbacks {
 
 export default function LemmaActionButton({
   token,
-  disabled,
   onResetCurrent,
   onMouseEnter,
   onMouseLeave,
   onMultiApply,
   onMultiReset,
 }: {
-  token: Token
-  disabled: boolean
+  token: EditableToken
 } & LemmaActionCallbacks): JSX.Element {
   return (
     <Dropdown as={ButtonGroup} className="lemmatizer__editor__action-button">
       <Button
         variant="secondary"
         onClick={onResetCurrent}
-        disabled={disabled}
+        disabled={!token.isDirty}
         aria-label="reset-current-token"
       >
         <i className={'fas fa-rotate-left'}></i>
       </Button>
 
-      <Dropdown.Toggle
-        split
-        variant="secondary"
-        id="dropdown-split-basic"
-        disabled={disabled}
-      >
+      <Dropdown.Toggle split variant="secondary" id="dropdown-split-basic">
         <i className={'fas fa-caret-down'}></i>
       </Dropdown.Toggle>
 
@@ -49,15 +42,16 @@ export default function LemmaActionButton({
           onMouseLeave={onMouseLeave}
           onClick={onMultiApply}
         >
-          Update all instances of <DisplayToken token={token} />
+          Update all instances of <DisplayToken token={token.token} />
         </Dropdown.Item>
         <Dropdown.Divider />
         <Dropdown.Item
           onMouseEnter={onMouseEnter}
           onMouseLeave={onMouseLeave}
           onClick={onMultiReset}
+          disabled={!token.isDirty}
         >
-          Reset all instances of <DisplayToken token={token} />
+          Reset all instances of <DisplayToken token={token.token} />
         </Dropdown.Item>
       </Dropdown.Menu>
     </Dropdown>

--- a/src/fragmentarium/ui/fragment/lemma-annotation/LemmaEditorModal.tsx
+++ b/src/fragmentarium/ui/fragment/lemma-annotation/LemmaEditorModal.tsx
@@ -66,11 +66,7 @@ export default function LemmaEditorModal({
                     onTab={callbacks.selectNextToken}
                     onShiftTab={callbacks.selectPreviousToken}
                   />
-                  <LemmaActionButton
-                    token={token.token}
-                    disabled={!token.isDirty}
-                    {...callbacks}
-                  />
+                  <LemmaActionButton token={token} {...callbacks} />
                 </>
               )}
             </Form.Group>

--- a/src/fragmentarium/ui/fragment/linguistic-annotation/EditableToken.tsx
+++ b/src/fragmentarium/ui/fragment/linguistic-annotation/EditableToken.tsx
@@ -112,7 +112,7 @@ export default class EditableToken {
     return this
   }
 
-  isNewLemma(lemma: LemmaOption): boolean {
+  private isNewLemma(lemma: LemmaOption): boolean {
     return !_.some(this.initialLemmas, (other) => lemma.value === other.value)
   }
 


### PR DESCRIPTION
The lemma-autofill sometimes suggests erroneous lemmas. The user can delete them individually, but deleting a suggestion on a previously unlemmatized token will result in it being clean (not edited). As a result, the user cannot batch-apply the change (no lemma) to all instances and either needs to discard them individually, leave them in a suggested state til saving, or save them with a random lemma, rerun the autofill, and delete, which will make the token "dirty". 

This PR solves the issue by making the batch-apply button _always_ available. It will always apply the lemmas of the currently selected token to similar tokens. If the currently selected token has unconfirmed suggestions (yellow badge), they will be set to confirmed and applied to all.