### PR TITLE
Extend TranslationColumn

### DIFF
--- a/src/fragmentarium/ui/display/Display.test.tsx
+++ b/src/fragmentarium/ui/display/Display.test.tsx
@@ -74,7 +74,7 @@ describe('Translation display layouts', () => {
 
       expect(screen.queryByText(/en\s*:/)).not.toBeInTheDocument()
       expect(screen.getByTestId('translation-for-line-0')).toHaveClass(
-        'TranslationColumn__translation'
+        'TranslationColumn'
       )
     })
   })

--- a/src/fragmentarium/ui/display/__snapshots__/Display.test.tsx.snap
+++ b/src/fragmentarium/ui/display/__snapshots__/Display.test.tsx.snap
@@ -466,7 +466,7 @@ exports[`correctly displays simple fragments 1`] = `
           <td />
           <td
             class="Transliteration__RulingDollarLine"
-            colspan="6"
+            colspan="4"
           >
             <div
               class="Transliteration__ruling"
@@ -633,7 +633,7 @@ exports[`correctly displays simple fragments 1`] = `
           <td />
           <td
             class="Transliteration__RulingDollarLine"
-            colspan="6"
+            colspan="4"
           >
             <div
               class="Transliteration__ruling"
@@ -1435,7 +1435,7 @@ exports[`correctly displays simple fragments 1`] = `
           <td />
           <td
             class="Transliteration__RulingDollarLine"
-            colspan="6"
+            colspan="4"
           >
             <div
               class="Transliteration__ruling"

--- a/src/transliteration/ui/TranslationColumn.sass
+++ b/src/transliteration/ui/TranslationColumn.sass
@@ -1,8 +1,10 @@
 .TranslationColumn
-  &__translation
-    color: initial
-    padding-left: 0.2em
-    width: 50%
-    border-left: 2px solid transparent
-    &:hover
-      border-left: 2px solid lightgray
+  color: initial
+  padding-left: 0.2em
+  width: 50%
+  border-left: 2px solid transparent
+  &:hover
+    border-left: 2px solid lightgray
+
+  &.lang-ar
+    text-align: right

--- a/src/transliteration/ui/TranslationColumn.tsx
+++ b/src/transliteration/ui/TranslationColumn.tsx
@@ -14,6 +14,7 @@ import {
 import lineNumberToString from 'transliteration/domain/lineNumberToString'
 import './TranslationColumn.sass'
 import { LineNumber, LineNumberRange } from 'transliteration/domain/line-number'
+import classNames from 'classnames'
 
 function getTranslationLines(
   lines: readonly AbstractLine[],
@@ -69,7 +70,7 @@ export default function TranslationColumn({
     <>
       <TransliterationTd
         type="TranslationLine"
-        className={'TranslationColumn__translation'}
+        className={classNames('TranslationColumn', `lang-${language}`)}
         title={createTranslationExtentLabel(
           line.lineNumber,
           translationLine.extent?.number

--- a/src/transliteration/ui/TranslationColumn.tsx
+++ b/src/transliteration/ui/TranslationColumn.tsx
@@ -1,7 +1,6 @@
 import _ from 'lodash'
 import React from 'react'
 import { AbstractLine } from 'transliteration/domain/abstract-line'
-import { TextLine } from 'transliteration/domain/text-line'
 import TranslationLine, {
   Extent,
 } from 'transliteration/domain/translation-line'
@@ -29,16 +28,17 @@ function getTranslationLines(
 function getRowSpan(
   lines: readonly AbstractLine[],
   lineIndex: number,
-  extent: Extent
+  extent: Extent,
+  language: string
 ): number {
-  const end = _.findIndex(
-    lines,
-    (line, index) =>
-      index > lineIndex &&
-      line.type === 'TextLine' &&
-      _.isEqual((line as TextLine).lineNumber, extent.number)
+  return (
+    _(lines)
+      .slice(lineIndex + 1)
+      .reject((line) => isTranslationLine(line) && line.language !== language)
+      .findIndex(
+        (line) => isTextLine(line) && _.isEqual(line.lineNumber, extent.number)
+      ) + 1
   )
-  return end - lineIndex
 }
 
 function createTranslationExtentLabel(
@@ -77,7 +77,7 @@ export default function TranslationColumn({
         )}
         rowSpan={
           translationLine.extent
-            ? getRowSpan(lines, lineIndex, translationLine.extent)
+            ? getRowSpan(lines, lineIndex, translationLine.extent, language)
             : 1
         }
         data-testid={`translation-for-line-${lineIndex}`}

--- a/src/transliteration/ui/TransliterationLines.tsx
+++ b/src/transliteration/ui/TransliterationLines.tsx
@@ -172,7 +172,6 @@ function DisplayTwoColumnText({
             line: AbstractLine,
             index: number
           ) => {
-            const rulingsOffset = line.type === 'RulingDollarLine' ? 2 : 0
             const rows = isTranslationLine(line)
               ? elements
               : [
@@ -181,7 +180,7 @@ function DisplayTwoColumnText({
                     key={index}
                     line={line}
                     lineIndex={index}
-                    columns={text.numberOfColumns + rulingsOffset}
+                    columns={text.numberOfColumns}
                     labels={labels}
                     activeLine={activeLine}
                     notes={text.notes}


### PR DESCRIPTION
- Right-align Arabic translations
- Limit rulings to transliteration columns
- Fix overlapping extents of translation lines with multiple languages