### PR TITLE
Retain Search Parameters in Advanced Search

### DIFF
--- a/src/fragmentarium/ui/SearchForm.sass
+++ b/src/fragmentarium/ui/SearchForm.sass
@@ -19,8 +19,10 @@
 
   &__advanced-link
     padding-bottom: 1rem
-    a
-      color: inherit
+    button
+      padding: 0
+      i
+        font-size: 80%
 
 .accordion-border-bottom
   border-bottom: 1px solid rgba(0, 0, 0, 0.125)

--- a/src/fragmentarium/ui/SearchForm.tsx
+++ b/src/fragmentarium/ui/SearchForm.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { withRouter, RouteComponentProps, Link } from 'react-router-dom'
+import { withRouter, RouteComponentProps } from 'react-router-dom'
 import { Button, ButtonToolbar, Col, Form, Row } from 'react-bootstrap'
 import { stringify } from 'query-string'
 import _ from 'lodash'
@@ -279,15 +279,9 @@ class SearchForm extends Component<SearchFormProps, State> {
                     className={'SearchForm__help-col'}
                   ></Col>
                   <Col>
-                    <Link
-                      to={
-                        this.props.project
-                          ? `/projects/${this.props.project}/search`
-                          : '/library/search'
-                      }
-                    >
-                      Advanced Search
-                    </Link>
+                    <Button variant="link" onClick={this.search}>
+                      Advanced Search <i className={'fas fa-external-link'}></i>
+                    </Button>
                   </Col>
                 </Row>
               )}

--- a/src/research-projects/subpages/__snapshots__/subpages.test.tsx.snap
+++ b/src/research-projects/subpages/__snapshots__/subpages.test.tsx.snap
@@ -438,11 +438,15 @@ exports[`Project pages displays AMPS page 1`] = `
                         <div
                           class="col"
                         >
-                          <a
-                            href="/projects/AMPS/search"
+                          <button
+                            class="btn btn-link"
+                            type="button"
                           >
-                            Advanced Search
-                          </a>
+                            Advanced Search 
+                            <i
+                              class="fas fa-external-link"
+                            />
+                          </button>
                         </div>
                       </div>
                     </div>
@@ -946,11 +950,15 @@ exports[`Project pages displays CAIC page 1`] = `
                         <div
                           class="col"
                         >
-                          <a
-                            href="/projects/CAIC/search"
+                          <button
+                            class="btn btn-link"
+                            type="button"
                           >
-                            Advanced Search
-                          </a>
+                            Advanced Search 
+                            <i
+                              class="fas fa-external-link"
+                            />
+                          </button>
                         </div>
                       </div>
                     </div>
@@ -1510,11 +1518,15 @@ exports[`Project pages displays aluGeneva page 1`] = `
                         <div
                           class="col"
                         >
-                          <a
-                            href="/projects/aluGeneva/search"
+                          <button
+                            class="btn btn-link"
+                            type="button"
                           >
-                            Advanced Search
-                          </a>
+                            Advanced Search 
+                            <i
+                              class="fas fa-external-link"
+                            />
+                          </button>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
Filters set in the simple search view /library are not carried over to the advanced search /library/search.  This PR fixes this by mirroring the behavior of clicking "Search", which results in the desired behavior.