### PR TITLE
fix: prefetch & parallelize provenances, fix missing abbreviations

### DIFF
--- a/src/InjectedApp.test.tsx
+++ b/src/InjectedApp.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import Bluebird from 'bluebird'
+import { AuthenticationContext } from 'auth/Auth'
+import type { AuthenticationService } from 'auth/Auth'
+import { guestSession } from 'auth/Session'
+import FragmentService from 'fragmentarium/application/FragmentService'
+import TextService from 'corpus/application/TextService'
+import InjectedApp from './InjectedApp'
+import type { ErrorReporter } from 'ErrorReporterContext'
+
+jest.mock('./App', () => {
+  return function MockApp() {
+    return <div data-testid="app">App</div>
+  }
+})
+
+jest.mock('http/ApiClient')
+jest.mock('dictionary/infrastructure/WordRepository')
+jest.mock('fragmentarium/infrastructure/FragmentRepository')
+jest.mock('fragmentarium/infrastructure/ImageRepository')
+jest.mock('bibliography/infrastructure/BibliographyRepository')
+jest.mock('fragmentarium/application/FragmentService')
+jest.mock('dictionary/application/WordService')
+jest.mock('bibliography/application/BibliographyService')
+jest.mock('corpus/application/TextService')
+jest.mock('fragmentarium/application/FragmentSearchService')
+jest.mock('signs/application/SignService')
+jest.mock('signs/infrastructure/SignRepository')
+jest.mock('afo-register/infrastructure/AfoRegisterRepository')
+jest.mock('markup/application/MarkupService')
+jest.mock('afo-register/application/AfoRegisterService')
+jest.mock('fragmentarium/application/FindspotService')
+jest.mock('fragmentarium/infrastructure/FindspotRepository')
+jest.mock('dossiers/application/DossiersService')
+jest.mock('dossiers/infrastructure/DossiersRepository')
+
+const mockAuthService: AuthenticationService = {
+  login: jest.fn(),
+  logout: jest.fn().mockResolvedValue(undefined),
+  getSession: jest.fn().mockReturnValue(guestSession),
+  isAuthenticated: jest.fn().mockReturnValue(false),
+  getAccessToken: jest.fn(),
+  getUser: jest.fn(),
+}
+
+const mockErrorReporter: ErrorReporter = {
+  captureException: jest.fn(),
+  showReportDialog: jest.fn(),
+  setUser: jest.fn(),
+  clearScope: jest.fn(),
+}
+
+function renderInjectedApp() {
+  return render(
+    <AuthenticationContext.Provider value={mockAuthService}>
+      <InjectedApp errorReporter={mockErrorReporter} />
+    </AuthenticationContext.Provider>,
+  )
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  FragmentService.prototype.fetchProvenances = jest
+    .fn()
+    .mockReturnValue(Bluebird.resolve([]))
+  FragmentService.prototype.fetchGenres = jest
+    .fn()
+    .mockReturnValue(Bluebird.resolve([]))
+  TextService.prototype.list = jest.fn().mockReturnValue(Bluebird.resolve([]))
+})
+
+describe('InjectedApp', () => {
+  test('renders App component', () => {
+    renderInjectedApp()
+    expect(screen.getByTestId('app')).toBeInTheDocument()
+  })
+
+  test('prefetches provenances on mount', async () => {
+    renderInjectedApp()
+    await waitFor(() => {
+      expect(FragmentService.prototype.fetchProvenances).toHaveBeenCalled()
+    })
+  })
+
+  test('prefetches text list on mount', async () => {
+    renderInjectedApp()
+    await waitFor(() => {
+      expect(TextService.prototype.list).toHaveBeenCalled()
+    })
+  })
+
+  test('prefetches genres on mount', async () => {
+    renderInjectedApp()
+    await waitFor(() => {
+      expect(FragmentService.prototype.fetchGenres).toHaveBeenCalled()
+    })
+  })
+
+  test('reports provenance prefetch error to errorReporter', async () => {
+    const error = new Error('provenance error')
+    FragmentService.prototype.fetchProvenances = jest
+      .fn()
+      .mockReturnValue(Bluebird.reject(error))
+
+    renderInjectedApp()
+
+    await waitFor(() => {
+      expect(mockErrorReporter.captureException).toHaveBeenCalledWith(error)
+    })
+  })
+
+  test('handles text list prefetch error gracefully', async () => {
+    TextService.prototype.list = jest
+      .fn()
+      .mockReturnValue(Bluebird.reject(new Error('list error')))
+
+    renderInjectedApp()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('app')).toBeInTheDocument()
+    })
+  })
+
+  test('handles genres prefetch error gracefully', async () => {
+    FragmentService.prototype.fetchGenres = jest
+      .fn()
+      .mockReturnValue(Bluebird.reject(new Error('genres error')))
+
+    renderInjectedApp()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('app')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/InjectedApp.test.tsx
+++ b/src/InjectedApp.test.tsx
@@ -110,27 +110,29 @@ describe('InjectedApp', () => {
     })
   })
 
-  test('handles text list prefetch error gracefully', async () => {
+  test('reports text list prefetch error to errorReporter', async () => {
+    const error = new Error('list error')
     TextService.prototype.list = jest
       .fn()
-      .mockReturnValue(Bluebird.reject(new Error('list error')))
+      .mockReturnValue(Bluebird.reject(error))
 
     renderInjectedApp()
 
     await waitFor(() => {
-      expect(screen.getByTestId('app')).toBeInTheDocument()
+      expect(mockErrorReporter.captureException).toHaveBeenCalledWith(error)
     })
   })
 
-  test('handles genres prefetch error gracefully', async () => {
+  test('reports genres prefetch error to errorReporter', async () => {
+    const error = new Error('genres error')
     FragmentService.prototype.fetchGenres = jest
       .fn()
-      .mockReturnValue(Bluebird.reject(new Error('genres error')))
+      .mockReturnValue(Bluebird.reject(error))
 
     renderInjectedApp()
 
     await waitFor(() => {
-      expect(screen.getByTestId('app')).toBeInTheDocument()
+      expect(mockErrorReporter.captureException).toHaveBeenCalledWith(error)
     })
   })
 })

--- a/src/InjectedApp.tsx
+++ b/src/InjectedApp.tsx
@@ -128,8 +128,12 @@ export default function InjectedApp({
     fragmentService.fetchProvenances().catch((error) => {
       errorReporter.captureException(error)
     })
-    textService.list().catch(() => {})
-    fragmentService.fetchGenres().catch(() => {})
+    textService.list().catch((error) => {
+      errorReporter.captureException(error)
+    })
+    fragmentService.fetchGenres().catch((error) => {
+      errorReporter.captureException(error)
+    })
   }, [fragmentService, textService, errorReporter])
   return (
     <App

--- a/src/InjectedApp.tsx
+++ b/src/InjectedApp.tsx
@@ -1,0 +1,149 @@
+import React, { useEffect, useMemo } from 'react'
+import App from './App'
+
+import ApiClient from 'http/ApiClient'
+import WordRepository from 'dictionary/infrastructure/WordRepository'
+import FragmentRepository from 'fragmentarium/infrastructure/FragmentRepository'
+import ApiImageRepository from 'fragmentarium/infrastructure/ImageRepository'
+import BibliographyRepository from 'bibliography/infrastructure/BibliographyRepository'
+import FragmentService from 'fragmentarium/application/FragmentService'
+import WordService from 'dictionary/application/WordService'
+import BibliographyService from 'bibliography/application/BibliographyService'
+import TextService from 'corpus/application/TextService'
+import FragmentSearchService from 'fragmentarium/application/FragmentSearchService'
+import { useAuthentication } from 'auth/Auth'
+import SignService from 'signs/application/SignService'
+import SignRepository from 'signs/infrastructure/SignRepository'
+import AfoRegisterRepository from 'afo-register/infrastructure/AfoRegisterRepository'
+import MarkupService, {
+  CachedMarkupService,
+} from 'markup/application/MarkupService'
+import AfoRegisterService from 'afo-register/application/AfoRegisterService'
+import { FindspotService } from 'fragmentarium/application/FindspotService'
+import { ApiFindspotRepository } from 'fragmentarium/infrastructure/FindspotRepository'
+import DossiersService from 'dossiers/application/DossiersService'
+import DossiersRepository from 'dossiers/infrastructure/DossiersRepository'
+import { ErrorReporter } from 'ErrorReporterContext'
+
+export default function InjectedApp({
+  errorReporter,
+}: {
+  errorReporter: ErrorReporter
+}): JSX.Element {
+  const authenticationService = useAuthentication()
+  const apiClient = useMemo(
+    () => new ApiClient(authenticationService, errorReporter),
+    [authenticationService, errorReporter],
+  )
+  const wordRepository = useMemo(
+    () => new WordRepository(apiClient),
+    [apiClient],
+  )
+  const signsRepository = useMemo(
+    () => new SignRepository(apiClient),
+    [apiClient],
+  )
+  const fragmentRepository = useMemo(
+    () => new FragmentRepository(apiClient),
+    [apiClient],
+  )
+  const imageRepository = useMemo(
+    () => new ApiImageRepository(apiClient),
+    [apiClient],
+  )
+  const bibliographyRepository = useMemo(
+    () => new BibliographyRepository(apiClient),
+    [apiClient],
+  )
+  const afoRegisterRepository = useMemo(
+    () => new AfoRegisterRepository(apiClient),
+    [apiClient],
+  )
+  const findspotRepository = useMemo(
+    () => new ApiFindspotRepository(apiClient),
+    [apiClient],
+  )
+  const dossiersRepository = useMemo(
+    () => new DossiersRepository(apiClient),
+    [apiClient],
+  )
+
+  const bibliographyService = useMemo(
+    () => new BibliographyService(bibliographyRepository),
+    [bibliographyRepository],
+  )
+  const fragmentService = useMemo(
+    () =>
+      new FragmentService(
+        fragmentRepository,
+        imageRepository,
+        wordRepository,
+        bibliographyService,
+      ),
+    [fragmentRepository, imageRepository, wordRepository, bibliographyService],
+  )
+  const fragmentSearchService = useMemo(
+    () => new FragmentSearchService(fragmentRepository),
+    [fragmentRepository],
+  )
+  const wordService = useMemo(
+    () => new WordService(wordRepository),
+    [wordRepository],
+  )
+  const textService = useMemo(
+    () =>
+      new TextService(
+        apiClient,
+        fragmentService,
+        wordService,
+        bibliographyService,
+      ),
+    [apiClient, fragmentService, wordService, bibliographyService],
+  )
+  const signService = useMemo(
+    () => new SignService(signsRepository),
+    [signsRepository],
+  )
+  const markupService = useMemo(
+    () => new MarkupService(apiClient, bibliographyService),
+    [apiClient, bibliographyService],
+  )
+  const cachedMarkupService = useMemo(
+    () => new CachedMarkupService(apiClient, bibliographyService),
+    [apiClient, bibliographyService],
+  )
+  const afoRegisterService = useMemo(
+    () => new AfoRegisterService(afoRegisterRepository),
+    [afoRegisterRepository],
+  )
+  const dossiersService = useMemo(
+    () => new DossiersService(dossiersRepository),
+    [dossiersRepository],
+  )
+  const findspotService = useMemo(
+    () => new FindspotService(findspotRepository),
+    [findspotRepository],
+  )
+  useEffect(() => {
+    fragmentService.fetchProvenances().catch((error) => {
+      errorReporter.captureException(error)
+    })
+    textService.list().catch(() => {})
+    fragmentService.fetchGenres().catch(() => {})
+  }, [fragmentService, textService, errorReporter])
+  return (
+    <App
+      wordService={wordService}
+      signService={signService}
+      fragmentService={fragmentService}
+      fragmentSearchService={fragmentSearchService}
+      bibliographyService={bibliographyService}
+      textService={textService}
+      markupService={markupService}
+      cachedMarkupService={cachedMarkupService}
+      afoRegisterService={afoRegisterService}
+      dossiersService={dossiersService}
+      findspotService={findspotService}
+    />
+  )
+}

--- a/src/corpus/application/TextService.test.ts
+++ b/src/corpus/application/TextService.test.ts
@@ -664,3 +664,51 @@ describe('findManuscripts provenance preload', () => {
     expect(fragmentServiceMock.fetchProvenances).toHaveBeenCalledTimes(2)
   })
 })
+
+describe('list caching', () => {
+  let service: TextService
+
+  beforeEach(() => {
+    service = new TextService(
+      apiClient,
+      fragmentServiceMock,
+      wordServiceMock,
+      bibliographyServiceMock,
+    )
+  })
+
+  test('returns cached result on second call', async () => {
+    apiClient.fetchJson.mockReturnValue(Bluebird.resolve(textsDto))
+
+    const first = await service.list()
+    const second = await service.list()
+
+    expect(first).toEqual([text])
+    expect(second).toEqual([text])
+    expect(apiClient.fetchJson).toHaveBeenCalledTimes(1)
+  })
+
+  test('clears cache on error and allows retry', async () => {
+    const error = new Error('network error')
+
+    apiClient.fetchJson.mockReturnValueOnce(Bluebird.reject(error))
+
+    await expect(service.list()).rejects.toThrow('network error')
+
+    apiClient.fetchJson.mockReturnValueOnce(Bluebird.resolve(textsDto))
+
+    await expect(service.list()).resolves.toEqual([text])
+    expect(apiClient.fetchJson).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('loadProvenances delegation', () => {
+  test('delegates to fragmentService.fetchProvenances', async () => {
+    fragmentServiceMock.fetchProvenances.mockReturnValue(Bluebird.resolve([]))
+    apiClient.fetchJson.mockReturnValue(Bluebird.resolve(chapterDto))
+
+    await testService.findChapter(chapterId)
+
+    expect(fragmentServiceMock.fetchProvenances).toHaveBeenCalled()
+  })
+})

--- a/src/corpus/application/TextService.test.ts
+++ b/src/corpus/application/TextService.test.ts
@@ -489,6 +489,10 @@ const testData: TestData<TextService>[] = [
   ),
 ]
 
+beforeEach(() => {
+  fragmentServiceMock.fetchProvenances.mockReturnValue(Bluebird.resolve([]))
+})
+
 describe('TextService', () => testDelegation(testService, testData))
 
 test('findSuggestions', async () => {
@@ -609,9 +613,10 @@ describe('findManuscripts provenance preload', () => {
       .spyOn(console, 'error')
       .mockImplementation(() => undefined)
 
-    apiClient.fetchJson
-      .mockRejectedValueOnce(provenanceError)
-      .mockResolvedValueOnce(chapterDto.manuscripts)
+    fragmentServiceMock.fetchProvenances.mockReturnValueOnce(
+      Bluebird.reject(provenanceError),
+    )
+    apiClient.fetchJson.mockResolvedValueOnce(chapterDto.manuscripts)
 
     await expect(service.findManuscripts(chapterId)).resolves.toEqual(
       chapter.manuscripts,
@@ -621,7 +626,7 @@ describe('findManuscripts provenance preload', () => {
       'Failed to preload provenances',
       provenanceError,
     )
-    expect(apiClient.fetchJson).toHaveBeenCalledWith('/provenances', false)
+    expect(fragmentServiceMock.fetchProvenances).toHaveBeenCalled()
     expect(apiClient.fetchJson).toHaveBeenCalledWith(
       `${chapterUrl}/manuscripts`,
       false,
@@ -639,11 +644,15 @@ describe('findManuscripts provenance preload', () => {
 
     jest.spyOn(console, 'error').mockImplementation(() => undefined)
 
-    apiClient.fetchJson
-      .mockRejectedValueOnce(provenanceError)
-      .mockResolvedValueOnce(chapterDto.manuscripts)
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(chapterDto.manuscripts)
+    fragmentServiceMock.fetchProvenances.mockReturnValueOnce(
+      Bluebird.reject(provenanceError),
+    )
+    apiClient.fetchJson.mockResolvedValueOnce(chapterDto.manuscripts)
+
+    fragmentServiceMock.fetchProvenances.mockReturnValueOnce(
+      Bluebird.resolve([]),
+    )
+    apiClient.fetchJson.mockResolvedValueOnce(chapterDto.manuscripts)
 
     await expect(service.findManuscripts(chapterId)).resolves.toEqual(
       chapter.manuscripts,
@@ -652,9 +661,6 @@ describe('findManuscripts provenance preload', () => {
       chapter.manuscripts,
     )
 
-    const provenanceCalls = apiClient.fetchJson.mock.calls.filter(
-      ([path]) => path === '/provenances',
-    )
-    expect(provenanceCalls).toHaveLength(2)
+    expect(fragmentServiceMock.fetchProvenances).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/corpus/application/TextService.ts
+++ b/src/corpus/application/TextService.ts
@@ -20,7 +20,7 @@ import {
 import { Line, LineVariant, ManuscriptLine } from 'corpus/domain/line'
 import { LineDetails } from 'corpus/domain/line-details'
 import { Manuscript } from 'corpus/domain/manuscript'
-import { setProvenanceRecords } from 'corpus/domain/provenance'
+
 import SiglumAndTransliteration from 'corpus/domain/SiglumAndTransliteration'
 import { Text } from 'corpus/domain/text'
 import { TextId } from 'transliteration/domain/text-id'
@@ -56,7 +56,6 @@ import { ParallelLine } from 'transliteration/domain/parallel-line'
 import { CorpusQuery } from 'query/CorpusQuery'
 import { CorpusQueryResult } from 'query/QueryResult'
 import { ChapterSlugs, TextSlugs } from 'router/sitemap'
-import { ProvenanceRecord } from 'fragmentarium/domain/Provenance'
 
 class CorpusLemmatizationFactory extends AbstractLemmatizationFactory<
   Chapter,
@@ -142,7 +141,6 @@ export function createChapterUrl({
 
 export default class TextService {
   private readonly referenceInjector: ReferenceInjector
-  private provenancePreload: Bluebird<void> | null = null
 
   constructor(
     private readonly apiClient: ApiClient,
@@ -179,9 +177,13 @@ export default class TextService {
   }
 
   findChapter(id: ChapterId): Bluebird<Chapter> {
-    return this.apiClient
-      .fetchJson<Record<string, unknown>>(createChapterUrl(id), false)
-      .then(fromChapterDto)
+    return Bluebird.all([
+      this.loadProvenances(),
+      this.apiClient.fetchJson<Record<string, unknown>>(
+        createChapterUrl(id),
+        false,
+      ),
+    ]).then(([, dto]) => fromChapterDto(dto))
   }
 
   findChapterDisplay(
@@ -192,61 +194,62 @@ export default class TextService {
     const lineParams = _.isEmpty(lines)
       ? ''
       : `?${stringify({ lines, variants })}`
-    return this.apiClient
-      .fetchJson<ChapterDisplayDto>(
+    return Bluebird.all([
+      this.loadProvenances(),
+      this.apiClient.fetchJson<ChapterDisplayDto>(
         `${createChapterUrl(id)}/display${lineParams}`,
         false,
-      )
-      .then((chapter: ChapterDisplayDto) =>
-        Bluebird.all(
-          chapter.lines.map((line) =>
-            Bluebird.all([
-              Bluebird.all(
-                line.translation.map((translation) =>
-                  this.referenceInjector
-                    .injectReferencesToMarkup(translation.parts)
-                    .then(
-                      (parts) =>
-                        new TranslationLine({
-                          ...castDraft(translation),
-                          parts,
-                        }),
-                    ),
-                ),
-              ),
-              Bluebird.all(
-                line.variants.map((variant, index) =>
-                  this.findLineVariant(variant, index === 0),
-                ),
-              ),
-              Bluebird.all(
-                line.oldLineNumbers.map((oldLineNumberDto) =>
-                  this.referenceInjector.injectReferenceToOldLineNumber(
-                    oldLineNumberDto,
+      ),
+    ]).then(([, chapter]) =>
+      Bluebird.all(
+        chapter.lines.map((line) =>
+          Bluebird.all([
+            Bluebird.all(
+              line.translation.map((translation) =>
+                this.referenceInjector
+                  .injectReferencesToMarkup(translation.parts)
+                  .then(
+                    (parts) =>
+                      new TranslationLine({
+                        ...castDraft(translation),
+                        parts,
+                      }),
                   ),
+              ),
+            ),
+            Bluebird.all(
+              line.variants.map((variant, index) =>
+                this.findLineVariant(variant, index === 0),
+              ),
+            ),
+            Bluebird.all(
+              line.oldLineNumbers.map((oldLineNumberDto) =>
+                this.referenceInjector.injectReferenceToOldLineNumber(
+                  oldLineNumberDto,
                 ),
               ),
-            ]).then(([translation, variants, oldLineNumbers]) => ({
-              ...line,
-              translation,
-              variants,
-              oldLineNumbers,
-            })),
-          ),
-        ).then(
-          (lines) =>
-            new ChapterDisplay(
-              chapter.id,
-              chapter.textHasDoi,
-              chapter.textName,
-              chapter.isSingleStage,
-              chapter.title,
-              lines,
-              chapter.record,
-              chapter.atf,
             ),
+          ]).then(([translation, variants, oldLineNumbers]) => ({
+            ...line,
+            translation,
+            variants,
+            oldLineNumbers,
+          })),
         ),
-      )
+      ).then(
+        (lines) =>
+          new ChapterDisplay(
+            chapter.id,
+            chapter.textHasDoi,
+            chapter.textName,
+            chapter.isSingleStage,
+            chapter.title,
+            lines,
+            chapter.record,
+            chapter.atf,
+          ),
+      ),
+    )
   }
 
   findLineVariant(
@@ -286,9 +289,14 @@ export default class TextService {
     number: number,
     variantNumber: number,
   ): Bluebird<LineDetails> {
-    return this.apiClient
-      .fetchJson(`${createChapterUrl(id)}/lines/${number}`, false)
-      .then((json) => fromLineDetailsDto(json, variantNumber))
+    return Bluebird.all([
+      this.loadProvenances(),
+      this.apiClient.fetchJson(
+        `${createChapterUrl(id)}/lines/${number}`,
+        false,
+      ),
+    ])
+      .then(([, json]) => fromLineDetailsDto(json, variantNumber))
       .then((line) =>
         Bluebird.all(
           line.variants.map((variant) =>
@@ -364,32 +372,21 @@ export default class TextService {
   }
 
   findManuscripts(id: ChapterId): Bluebird<Manuscript[]> {
-    return this.loadProvenances()
-      .then(() =>
-        this.apiClient.fetchJson<unknown[]>(
-          `${createChapterUrl(id)}/manuscripts`,
-          false,
-        ),
-      )
-      .then((manuscripts) => manuscripts.map(fromManuscriptDto))
+    return Bluebird.all([
+      this.loadProvenances(),
+      this.apiClient.fetchJson<unknown[]>(
+        `${createChapterUrl(id)}/manuscripts`,
+        false,
+      ),
+    ]).then(([, manuscripts]) => manuscripts.map(fromManuscriptDto))
   }
 
   private loadProvenances(): Bluebird<void> {
-    if (this.provenancePreload) {
-      return this.provenancePreload
-    }
-
-    this.provenancePreload = this.apiClient
-      .fetchJson<readonly ProvenanceRecord[]>('/provenances', false)
-      .then((provenances) => {
-        setProvenanceRecords(provenances)
-      })
+    return Bluebird.resolve(this.fragmentService.fetchProvenances())
+      .then(() => undefined)
       .catch((error) => {
         console.error('Failed to preload provenances', error)
-        this.provenancePreload = null
       })
-
-    return this.provenancePreload
   }
 
   list(): Bluebird<Text[]> {
@@ -424,21 +421,26 @@ export default class TextService {
     id: ChapterId,
     alignment: ChapterAlignment,
   ): Bluebird<Chapter> {
-    return this.apiClient
-      .postJson(`${createChapterUrl(id)}/alignment`, toAlignmentDto(alignment))
-      .then(fromChapterDto)
+    return Bluebird.all([
+      this.loadProvenances(),
+      this.apiClient.postJson(
+        `${createChapterUrl(id)}/alignment`,
+        toAlignmentDto(alignment),
+      ),
+    ]).then(([, dto]) => fromChapterDto(dto))
   }
 
   updateLemmatization(
     id: ChapterId,
     lemmatization: ChapterLemmatization,
   ): Bluebird<Chapter> {
-    return this.apiClient
-      .postJson(
+    return Bluebird.all([
+      this.loadProvenances(),
+      this.apiClient.postJson(
         `${createChapterUrl(id)}/lemmatization`,
         toLemmatizationDto(lemmatization),
-      )
-      .then(fromChapterDto)
+      ),
+    ]).then(([, dto]) => fromChapterDto(dto))
   }
 
   updateManuscripts(
@@ -446,24 +448,30 @@ export default class TextService {
     manuscripts: readonly Manuscript[],
     uncertainChapters: readonly string[],
   ): Bluebird<Chapter> {
-    return this.apiClient
-      .postJson(
+    return Bluebird.all([
+      this.loadProvenances(),
+      this.apiClient.postJson(
         `${createChapterUrl(id)}/manuscripts`,
         toManuscriptsDto(manuscripts, uncertainChapters),
-      )
-      .then(fromChapterDto)
+      ),
+    ]).then(([, dto]) => fromChapterDto(dto))
   }
 
   updateLines(id: ChapterId, lines: readonly Line[]): Bluebird<Chapter> {
-    return this.apiClient
-      .postJson(`${createChapterUrl(id)}/lines`, toLinesDto(lines))
-      .then(fromChapterDto)
+    return Bluebird.all([
+      this.loadProvenances(),
+      this.apiClient.postJson(
+        `${createChapterUrl(id)}/lines`,
+        toLinesDto(lines),
+      ),
+    ]).then(([, dto]) => fromChapterDto(dto))
   }
 
   importChapter(id: ChapterId, atf: string): Bluebird<Chapter> {
-    return this.apiClient
-      .postJson(`${createChapterUrl(id)}/import`, { atf })
-      .then(fromChapterDto)
+    return Bluebird.all([
+      this.loadProvenances(),
+      this.apiClient.postJson(`${createChapterUrl(id)}/import`, { atf }),
+    ]).then(([, dto]) => fromChapterDto(dto))
   }
 
   findSuggestions(chapter: Chapter): Bluebird<ChapterLemmatization> {

--- a/src/corpus/application/TextService.ts
+++ b/src/corpus/application/TextService.ts
@@ -142,6 +142,8 @@ export function createChapterUrl({
 export default class TextService {
   private readonly referenceInjector: ReferenceInjector
 
+  private cachedTexts: Bluebird<Text[]> | null = null
+
   constructor(
     private readonly apiClient: ApiClient,
     private readonly fragmentService: FragmentService,
@@ -390,9 +392,16 @@ export default class TextService {
   }
 
   list(): Bluebird<Text[]> {
-    return this.apiClient
-      .fetchJson<unknown[]>('/texts', false)
-      .then((dtos) => dtos.map(fromDto))
+    if (!this.cachedTexts) {
+      this.cachedTexts = this.apiClient
+        .fetchJson<unknown[]>('/texts', false)
+        .then((dtos) => dtos.map(fromDto))
+        .catch((error) => {
+          this.cachedTexts = null
+          throw error
+        })
+    }
+    return this.cachedTexts
   }
 
   searchLemma(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -95,6 +95,7 @@ function InjectedApp(): JSX.Element {
   const afoRegisterService = new AfoRegisterService(afoRegisterRepository)
   const dossiersService = new DossiersService(dossiersRepository)
   const findspotService = new FindspotService(findspotRepository)
+  fragmentService.fetchProvenances().catch(() => {})
   return (
     <App
       wordService={wordService}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,45 +1,19 @@
-import React, {
-  PropsWithChildren,
-  useCallback,
-  useEffect,
-  useMemo,
-} from 'react'
+import React, { PropsWithChildren, useCallback, useMemo } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter as Router } from 'react-router-dom'
 import { useHistory } from 'router/compat'
 import Promise from 'bluebird'
-import App from './App'
 import ErrorBoundary from 'common/ErrorBoundary'
 import * as serviceWorker from './serviceWorker'
 
-import ApiClient from 'http/ApiClient'
-import WordRepository from 'dictionary/infrastructure/WordRepository'
-import FragmentRepository from 'fragmentarium/infrastructure/FragmentRepository'
-import ApiImageRepository from 'fragmentarium/infrastructure/ImageRepository'
-import BibliographyRepository from 'bibliography/infrastructure/BibliographyRepository'
-import FragmentService from 'fragmentarium/application/FragmentService'
-import WordService from 'dictionary/application/WordService'
 import ErrorReporterContext from './ErrorReporterContext'
 import SentryErrorReporter from 'common/SentryErrorReporter'
-import BibliographyService from 'bibliography/application/BibliographyService'
-import TextService from 'corpus/application/TextService'
 import createAuth0Config from 'auth/createAuth0Config'
-import FragmentSearchService from 'fragmentarium/application/FragmentSearchService'
 import { Auth0Provider } from 'auth/react-auth0-spa'
-import { scopeString, useAuthentication } from 'auth/Auth'
-import SignService from 'signs/application/SignService'
-import SignRepository from 'signs/infrastructure/SignRepository'
-import AfoRegisterRepository from 'afo-register/infrastructure/AfoRegisterRepository'
-import MarkupService, {
-  CachedMarkupService,
-} from 'markup/application/MarkupService'
-import AfoRegisterService from 'afo-register/application/AfoRegisterService'
+import { scopeString } from 'auth/Auth'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import './index.sass'
-import { FindspotService } from 'fragmentarium/application/FindspotService'
-import { ApiFindspotRepository } from 'fragmentarium/infrastructure/FindspotRepository'
-import DossiersService from 'dossiers/application/DossiersService'
-import DossiersRepository from 'dossiers/infrastructure/DossiersRepository'
+import InjectedApp from './InjectedApp'
 
 if (process.env.REACT_APP_SENTRY_DSN && process.env.NODE_ENV) {
   SentryErrorReporter.init(
@@ -62,125 +36,6 @@ export type JsonApiClient = {
     body: Record<string, unknown>,
     authorize?: boolean,
   ) => Promise<T>
-}
-
-function InjectedApp(): JSX.Element {
-  const authenticationService = useAuthentication()
-  const apiClient = useMemo(
-    () => new ApiClient(authenticationService, errorReporter),
-    [authenticationService],
-  )
-  const wordRepository = useMemo(
-    () => new WordRepository(apiClient),
-    [apiClient],
-  )
-  const signsRepository = useMemo(
-    () => new SignRepository(apiClient),
-    [apiClient],
-  )
-  const fragmentRepository = useMemo(
-    () => new FragmentRepository(apiClient),
-    [apiClient],
-  )
-  const imageRepository = useMemo(
-    () => new ApiImageRepository(apiClient),
-    [apiClient],
-  )
-  const bibliographyRepository = useMemo(
-    () => new BibliographyRepository(apiClient),
-    [apiClient],
-  )
-  const afoRegisterRepository = useMemo(
-    () => new AfoRegisterRepository(apiClient),
-    [apiClient],
-  )
-  const findspotRepository = useMemo(
-    () => new ApiFindspotRepository(apiClient),
-    [apiClient],
-  )
-  const dossiersRepository = useMemo(
-    () => new DossiersRepository(apiClient),
-    [apiClient],
-  )
-
-  const bibliographyService = useMemo(
-    () => new BibliographyService(bibliographyRepository),
-    [bibliographyRepository],
-  )
-  const fragmentService = useMemo(
-    () =>
-      new FragmentService(
-        fragmentRepository,
-        imageRepository,
-        wordRepository,
-        bibliographyService,
-      ),
-    [fragmentRepository, imageRepository, wordRepository, bibliographyService],
-  )
-  const fragmentSearchService = useMemo(
-    () => new FragmentSearchService(fragmentRepository),
-    [fragmentRepository],
-  )
-  const wordService = useMemo(
-    () => new WordService(wordRepository),
-    [wordRepository],
-  )
-  const textService = useMemo(
-    () =>
-      new TextService(
-        apiClient,
-        fragmentService,
-        wordService,
-        bibliographyService,
-      ),
-    [apiClient, fragmentService, wordService, bibliographyService],
-  )
-  const signService = useMemo(
-    () => new SignService(signsRepository),
-    [signsRepository],
-  )
-  const markupService = useMemo(
-    () => new MarkupService(apiClient, bibliographyService),
-    [apiClient, bibliographyService],
-  )
-  const cachedMarkupService = useMemo(
-    () => new CachedMarkupService(apiClient, bibliographyService),
-    [apiClient, bibliographyService],
-  )
-  const afoRegisterService = useMemo(
-    () => new AfoRegisterService(afoRegisterRepository),
-    [afoRegisterRepository],
-  )
-  const dossiersService = useMemo(
-    () => new DossiersService(dossiersRepository),
-    [dossiersRepository],
-  )
-  const findspotService = useMemo(
-    () => new FindspotService(findspotRepository),
-    [findspotRepository],
-  )
-  useEffect(() => {
-    fragmentService.fetchProvenances().catch((error) => {
-      errorReporter.captureException(error)
-    })
-    textService.list().catch(() => {})
-    fragmentService.fetchGenres().catch(() => {})
-  }, [fragmentService, textService])
-  return (
-    <App
-      wordService={wordService}
-      signService={signService}
-      fragmentService={fragmentService}
-      fragmentSearchService={fragmentSearchService}
-      bibliographyService={bibliographyService}
-      textService={textService}
-      markupService={markupService}
-      cachedMarkupService={cachedMarkupService}
-      afoRegisterService={afoRegisterService}
-      dossiersService={dossiersService}
-      findspotService={findspotService}
-    />
-  )
 }
 
 function InjectedAuth0Provider({
@@ -231,7 +86,7 @@ root.render(
         <div className="mh-100">
           <div>
             <InjectedAuth0Provider>
-              <InjectedApp />
+              <InjectedApp errorReporter={errorReporter} />
             </InjectedAuth0Provider>
           </div>
         </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -66,45 +66,106 @@ export type JsonApiClient = {
 
 function InjectedApp(): JSX.Element {
   const authenticationService = useAuthentication()
-  const apiClient = new ApiClient(authenticationService, errorReporter)
-  const wordRepository = new WordRepository(apiClient)
-  const signsRepository = new SignRepository(apiClient)
-  const fragmentRepository = new FragmentRepository(apiClient)
-  const imageRepository = new ApiImageRepository(apiClient)
-  const bibliographyRepository = new BibliographyRepository(apiClient)
-  const afoRegisterRepository = new AfoRegisterRepository(apiClient)
-  const findspotRepository = new ApiFindspotRepository(apiClient)
-  const dossiersRepository = new DossiersRepository(apiClient)
+  const apiClient = useMemo(
+    () => new ApiClient(authenticationService, errorReporter),
+    [authenticationService],
+  )
+  const wordRepository = useMemo(
+    () => new WordRepository(apiClient),
+    [apiClient],
+  )
+  const signsRepository = useMemo(
+    () => new SignRepository(apiClient),
+    [apiClient],
+  )
+  const fragmentRepository = useMemo(
+    () => new FragmentRepository(apiClient),
+    [apiClient],
+  )
+  const imageRepository = useMemo(
+    () => new ApiImageRepository(apiClient),
+    [apiClient],
+  )
+  const bibliographyRepository = useMemo(
+    () => new BibliographyRepository(apiClient),
+    [apiClient],
+  )
+  const afoRegisterRepository = useMemo(
+    () => new AfoRegisterRepository(apiClient),
+    [apiClient],
+  )
+  const findspotRepository = useMemo(
+    () => new ApiFindspotRepository(apiClient),
+    [apiClient],
+  )
+  const dossiersRepository = useMemo(
+    () => new DossiersRepository(apiClient),
+    [apiClient],
+  )
 
-  const bibliographyService = new BibliographyService(bibliographyRepository)
-  const fragmentService = new FragmentService(
-    fragmentRepository,
-    imageRepository,
-    wordRepository,
-    bibliographyService,
+  const bibliographyService = useMemo(
+    () => new BibliographyService(bibliographyRepository),
+    [bibliographyRepository],
   )
-  const fragmentSearchService = new FragmentSearchService(fragmentRepository)
-  const wordService = new WordService(wordRepository)
-  const textService = new TextService(
-    apiClient,
-    fragmentService,
-    wordService,
-    bibliographyService,
+  const fragmentService = useMemo(
+    () =>
+      new FragmentService(
+        fragmentRepository,
+        imageRepository,
+        wordRepository,
+        bibliographyService,
+      ),
+    [fragmentRepository, imageRepository, wordRepository, bibliographyService],
   )
-  const signService = new SignService(signsRepository)
-  const markupService = new MarkupService(apiClient, bibliographyService)
-  const cachedMarkupService = new CachedMarkupService(
-    apiClient,
-    bibliographyService,
+  const fragmentSearchService = useMemo(
+    () => new FragmentSearchService(fragmentRepository),
+    [fragmentRepository],
   )
-  const afoRegisterService = new AfoRegisterService(afoRegisterRepository)
-  const dossiersService = new DossiersService(dossiersRepository)
-  const findspotService = new FindspotService(findspotRepository)
+  const wordService = useMemo(
+    () => new WordService(wordRepository),
+    [wordRepository],
+  )
+  const textService = useMemo(
+    () =>
+      new TextService(
+        apiClient,
+        fragmentService,
+        wordService,
+        bibliographyService,
+      ),
+    [apiClient, fragmentService, wordService, bibliographyService],
+  )
+  const signService = useMemo(
+    () => new SignService(signsRepository),
+    [signsRepository],
+  )
+  const markupService = useMemo(
+    () => new MarkupService(apiClient, bibliographyService),
+    [apiClient, bibliographyService],
+  )
+  const cachedMarkupService = useMemo(
+    () => new CachedMarkupService(apiClient, bibliographyService),
+    [apiClient, bibliographyService],
+  )
+  const afoRegisterService = useMemo(
+    () => new AfoRegisterService(afoRegisterRepository),
+    [afoRegisterRepository],
+  )
+  const dossiersService = useMemo(
+    () => new DossiersService(dossiersRepository),
+    [dossiersRepository],
+  )
+  const findspotService = useMemo(
+    () => new FindspotService(findspotRepository),
+    [findspotRepository],
+  )
   useEffect(() => {
     fragmentService.fetchProvenances().catch((error) => {
       errorReporter.captureException(error)
     })
-  }, [fragmentService])
+    textService.list().catch(() => {})
+    fragmentService.fetchGenres().catch(() => {})
+  }, [fragmentService, textService])
   return (
     <App
       wordService={wordService}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,9 @@
-import React, { PropsWithChildren, useCallback, useMemo } from 'react'
+import React, {
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useMemo,
+} from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter as Router } from 'react-router-dom'
 import { useHistory } from 'router/compat'
@@ -95,7 +100,11 @@ function InjectedApp(): JSX.Element {
   const afoRegisterService = new AfoRegisterService(afoRegisterRepository)
   const dossiersService = new DossiersService(dossiersRepository)
   const findspotService = new FindspotService(findspotRepository)
-  fragmentService.fetchProvenances().catch(() => {})
+  useEffect(() => {
+    fragmentService.fetchProvenances().catch((error) => {
+      errorReporter.captureException(error)
+    })
+  }, [])
   return (
     <App
       wordService={wordService}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -104,7 +104,7 @@ function InjectedApp(): JSX.Element {
     fragmentService.fetchProvenances().catch((error) => {
       errorReporter.captureException(error)
     })
-  }, [])
+  }, [fragmentService])
   return (
     <App
       wordService={wordService}


### PR DESCRIPTION
Prefetch provenances in app to make it easily fetchable for library search. Parallelize provenance load ups with corpus to prevent sequential loading. Fixed missing abbreviations by ensuring all provenances are loaded before deserialization.