### PR TITLE
dev: addressing fan-out

### DIFF
--- a/src/InjectedApp.tsx
+++ b/src/InjectedApp.tsx
@@ -166,8 +166,11 @@ export default function InjectedApp({
     [afoRegisterRepository],
   )
   const dossiersService = useMemo(
-    () => new DossiersService(dossiersRepository),
-    [dossiersRepository],
+    () =>
+      new DossiersService(dossiersRepository, () =>
+        getFragmentCacheScope(authenticationService),
+      ),
+    [dossiersRepository, authenticationService],
   )
   const findspotService = useMemo(
     () => new FindspotService(findspotRepository),

--- a/src/dossiers/application/DossiersService.test.ts
+++ b/src/dossiers/application/DossiersService.test.ts
@@ -3,14 +3,21 @@ import DossierRecord, {
   DossierRecordSuggestion,
 } from 'dossiers/domain/DossierRecord'
 import DossiersService from 'dossiers/application/DossiersService'
+import Bluebird from 'bluebird'
 
 jest.mock('dossiers/infrastructure/DossiersRepository')
 
 const dossiersRepository =
   new (DossiersRepository as jest.Mock)() as jest.Mocked<DossiersRepository>
+const cacheEntryLifetimeInMilliseconds = 5 * 60 * 1000
 
-const createRecord = (id: string): DossierRecord =>
-  new DossierRecord({ _id: id })
+const createRecord = (id: string, description?: string): DossierRecord =>
+  new DossierRecord({ _id: id, description })
+
+const flushMicrotasks = () =>
+  new Promise<void>((resolve) => {
+    queueMicrotask(resolve)
+  })
 
 const suggestion = new DossierRecordSuggestion({
   id: 'D001',
@@ -19,10 +26,18 @@ const suggestion = new DossierRecordSuggestion({
 
 describe('DossiersService', () => {
   let dossiersService: DossiersService
+  let cacheScope: string
+  let currentTime: number
 
   beforeEach(() => {
     jest.clearAllMocks()
-    dossiersService = new DossiersService(dossiersRepository)
+    cacheScope = 'guest'
+    currentTime = 0
+    dossiersService = new DossiersService(
+      dossiersRepository,
+      () => cacheScope,
+      () => currentTime,
+    )
   })
 
   it('batches concurrent queryByIds requests', async () => {
@@ -40,6 +55,29 @@ describe('DossiersService', () => {
     expect(dossiersRepository.queryByIds).toHaveBeenCalledWith(['A', 'B', 'C'])
   })
 
+  it('reuses in-flight result for duplicate ids requested while fetching', async () => {
+    const recordA = createRecord('A')
+    let resolveFirstRequest: ((records: DossierRecord[]) => void) | undefined
+    dossiersRepository.queryByIds.mockImplementationOnce(
+      () =>
+        new Bluebird<DossierRecord[]>((resolve) => {
+          resolveFirstRequest = resolve
+        }),
+    )
+
+    const firstRequest = dossiersService.queryByIds(['A'])
+    await flushMicrotasks()
+    const secondRequest = dossiersService.queryByIds(['A'])
+
+    expect(dossiersRepository.queryByIds).toHaveBeenCalledTimes(1)
+
+    resolveFirstRequest?.([recordA])
+
+    await expect(firstRequest).resolves.toEqual([recordA])
+    await expect(secondRequest).resolves.toEqual([recordA])
+    expect(dossiersRepository.queryByIds).toHaveBeenCalledTimes(1)
+  })
+
   it('returns cached dossiers without calling repository', async () => {
     const recordA = createRecord('A')
     dossiersRepository.queryByIds.mockResolvedValueOnce([recordA])
@@ -49,6 +87,94 @@ describe('DossiersService', () => {
 
     await expect(dossiersService.queryByIds(['A'])).resolves.toEqual([recordA])
     expect(dossiersRepository.queryByIds).not.toHaveBeenCalled()
+  })
+
+  it('clears cached dossiers when auth scope changes', async () => {
+    const guestRecord = createRecord('A', 'guest')
+    const authenticatedRecord = createRecord('A', 'authenticated')
+    dossiersRepository.queryByIds
+      .mockResolvedValueOnce([guestRecord])
+      .mockResolvedValueOnce([authenticatedRecord])
+
+    await expect(dossiersService.queryByIds(['A'])).resolves.toEqual([
+      guestRecord,
+    ])
+
+    cacheScope = 'authenticated:user'
+
+    await expect(dossiersService.queryByIds(['A'])).resolves.toEqual([
+      authenticatedRecord,
+    ])
+    expect(dossiersRepository.queryByIds).toHaveBeenNthCalledWith(1, ['A'])
+    expect(dossiersRepository.queryByIds).toHaveBeenNthCalledWith(2, ['A'])
+
+    dossiersRepository.queryByIds.mockClear()
+
+    await expect(dossiersService.queryByIds(['A'])).resolves.toEqual([
+      authenticatedRecord,
+    ])
+    expect(dossiersRepository.queryByIds).not.toHaveBeenCalled()
+  })
+
+  it('does not leak in-flight query results into a new auth scope cache', async () => {
+    const guestRecord = createRecord('A', 'guest')
+    const authenticatedRecord = createRecord('A', 'authenticated')
+    let resolveGuestRequest: ((records: DossierRecord[]) => void) | undefined
+    dossiersRepository.queryByIds
+      .mockImplementationOnce(
+        () =>
+          new Bluebird<DossierRecord[]>((resolve) => {
+            resolveGuestRequest = resolve
+          }),
+      )
+      .mockResolvedValueOnce([authenticatedRecord])
+
+    const guestRequest = dossiersService.queryByIds(['A'])
+
+    await flushMicrotasks()
+
+    cacheScope = 'authenticated:user'
+
+    const authenticatedRequest = dossiersService.queryByIds(['A'])
+
+    resolveGuestRequest?.([guestRecord])
+
+    await expect(guestRequest).resolves.toEqual([guestRecord])
+    await expect(authenticatedRequest).resolves.toEqual([authenticatedRecord])
+
+    dossiersRepository.queryByIds.mockClear()
+
+    await expect(dossiersService.queryByIds(['A'])).resolves.toEqual([
+      authenticatedRecord,
+    ])
+    expect(dossiersRepository.queryByIds).not.toHaveBeenCalled()
+  })
+
+  it('refetches dossier ids after cache entry expires', async () => {
+    const firstRecord = createRecord('A', 'first')
+    const refreshedRecord = createRecord('A', 'refreshed')
+    dossiersRepository.queryByIds.mockResolvedValueOnce([firstRecord])
+
+    await expect(dossiersService.queryByIds(['A'])).resolves.toEqual([
+      firstRecord,
+    ])
+
+    dossiersRepository.queryByIds.mockClear()
+    currentTime = cacheEntryLifetimeInMilliseconds - 1
+
+    await expect(dossiersService.queryByIds(['A'])).resolves.toEqual([
+      firstRecord,
+    ])
+    expect(dossiersRepository.queryByIds).not.toHaveBeenCalled()
+
+    dossiersRepository.queryByIds.mockResolvedValueOnce([refreshedRecord])
+    currentTime = cacheEntryLifetimeInMilliseconds
+
+    await expect(dossiersService.queryByIds(['A'])).resolves.toEqual([
+      refreshedRecord,
+    ])
+    expect(dossiersRepository.queryByIds).toHaveBeenCalledTimes(1)
+    expect(dossiersRepository.queryByIds).toHaveBeenCalledWith(['A'])
   })
 
   it('queries only missing dossier ids when partial cache exists', async () => {

--- a/src/dossiers/application/DossiersService.test.ts
+++ b/src/dossiers/application/DossiersService.test.ts
@@ -177,6 +177,37 @@ describe('DossiersService', () => {
     expect(dossiersRepository.queryByIds).toHaveBeenCalledWith(['A'])
   })
 
+  it('evicts least recently used dossiers when cache limit is reached', async () => {
+    const recordA = createRecord('A', 'A')
+    const recordB = createRecord('B', 'B')
+    const recordC = createRecord('C', 'C')
+    const maximumCachedDossiers = 2
+    dossiersService = new DossiersService(
+      dossiersRepository,
+      () => cacheScope,
+      () => currentTime,
+      maximumCachedDossiers,
+    )
+
+    dossiersRepository.queryByIds
+      .mockResolvedValueOnce([recordA])
+      .mockResolvedValueOnce([recordB])
+      .mockResolvedValueOnce([recordC])
+
+    await expect(dossiersService.queryByIds(['A'])).resolves.toEqual([recordA])
+    await expect(dossiersService.queryByIds(['B'])).resolves.toEqual([recordB])
+    await expect(dossiersService.queryByIds(['A'])).resolves.toEqual([recordA])
+    await expect(dossiersService.queryByIds(['C'])).resolves.toEqual([recordC])
+
+    dossiersRepository.queryByIds.mockClear()
+    dossiersRepository.queryByIds.mockResolvedValueOnce([recordB])
+
+    await expect(dossiersService.queryByIds(['A'])).resolves.toEqual([recordA])
+    await expect(dossiersService.queryByIds(['B'])).resolves.toEqual([recordB])
+    expect(dossiersRepository.queryByIds).toHaveBeenCalledTimes(1)
+    expect(dossiersRepository.queryByIds).toHaveBeenCalledWith(['B'])
+  })
+
   it('queries only missing dossier ids when partial cache exists', async () => {
     const recordA = createRecord('A')
     const recordB = createRecord('B')

--- a/src/dossiers/application/DossiersService.test.ts
+++ b/src/dossiers/application/DossiersService.test.ts
@@ -1,69 +1,141 @@
-import { testDelegation, TestData } from 'test-support/utils'
 import DossiersRepository from 'dossiers/infrastructure/DossiersRepository'
 import DossierRecord, {
   DossierRecordSuggestion,
 } from 'dossiers/domain/DossierRecord'
 import DossiersService from 'dossiers/application/DossiersService'
-import { stringify } from 'query-string'
-import { referenceFactory } from 'test-support/bibliography-fixtures'
 
 jest.mock('dossiers/infrastructure/DossiersRepository')
-const dossiersRepository = new (DossiersRepository as jest.Mock)()
 
-const dossiersService = new DossiersService(dossiersRepository)
+const dossiersRepository = new (DossiersRepository as jest.Mock<
+  jest.Mocked<DossiersRepository>
+>)()
 
-const resultStub = {
-  _id: 'test',
-  description: 'some desciption',
-  isApproximateDate: true,
-  yearRangeFrom: -500,
-  yearRangeTo: -470,
-  relatedKings: [10.2, 11],
-  provenance: 'Assyria',
-  script: {
-    period: 'Neo-Assyrian',
-    periodModifier: 'None',
-    uncertain: false,
-  },
-  references: [referenceFactory.build()],
-}
+const createRecord = (id: string): DossierRecord =>
+  new DossierRecord({ _id: id })
 
-const suggestionStub = {
+const suggestion = new DossierRecordSuggestion({
   id: 'D001',
   description: 'Test suggestion',
-}
-
-const query = { ids: ['test'] }
-const entry = new DossierRecord(resultStub)
-const suggestion = new DossierRecordSuggestion(suggestionStub)
-
-const testData: TestData<DossiersService>[] = [
-  new TestData(
-    'queryByIds',
-    [stringify(query, { arrayFormat: 'index' })],
-    dossiersRepository.queryByIds,
-    [entry],
-    [stringify(query, { arrayFormat: 'index' })],
-    Promise.resolve([entry]),
-  ),
-  new TestData(
-    'searchSuggestions',
-    ['test', undefined],
-    dossiersRepository.searchSuggestions,
-    [suggestion],
-    ['test', undefined],
-    Promise.resolve([suggestion]),
-  ),
-]
+})
 
 describe('DossiersService', () => {
-  testDelegation(dossiersService, testData)
+  let dossiersService: DossiersService
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    dossiersService = new DossiersService(dossiersRepository)
+  })
+
+  it('batches concurrent queryByIds requests', async () => {
+    const recordA = createRecord('A')
+    const recordB = createRecord('B')
+    const recordC = createRecord('C')
+    dossiersRepository.queryByIds.mockResolvedValue([recordA, recordB, recordC])
+
+    const firstRequest = dossiersService.queryByIds(['A', 'B'])
+    const secondRequest = dossiersService.queryByIds(['B', 'C'])
+
+    await expect(firstRequest).resolves.toEqual([recordA, recordB])
+    await expect(secondRequest).resolves.toEqual([recordB, recordC])
+    expect(dossiersRepository.queryByIds).toHaveBeenCalledTimes(1)
+    expect(dossiersRepository.queryByIds).toHaveBeenCalledWith(['A', 'B', 'C'])
+  })
+
+  it('returns cached dossiers without calling repository', async () => {
+    const recordA = createRecord('A')
+    dossiersRepository.queryByIds.mockResolvedValueOnce([recordA])
+
+    await expect(dossiersService.queryByIds(['A'])).resolves.toEqual([recordA])
+    dossiersRepository.queryByIds.mockClear()
+
+    await expect(dossiersService.queryByIds(['A'])).resolves.toEqual([recordA])
+    expect(dossiersRepository.queryByIds).not.toHaveBeenCalled()
+  })
+
+  it('queries only missing dossier ids when partial cache exists', async () => {
+    const recordA = createRecord('A')
+    const recordB = createRecord('B')
+    const recordC = createRecord('C')
+    dossiersRepository.queryByIds
+      .mockResolvedValueOnce([recordA, recordB])
+      .mockResolvedValueOnce([recordC])
+
+    await expect(dossiersService.queryByIds(['A', 'B'])).resolves.toEqual([
+      recordA,
+      recordB,
+    ])
+    await expect(dossiersService.queryByIds(['A', 'C'])).resolves.toEqual([
+      recordA,
+      recordC,
+    ])
+
+    expect(dossiersRepository.queryByIds).toHaveBeenNthCalledWith(1, ['A', 'B'])
+    expect(dossiersRepository.queryByIds).toHaveBeenNthCalledWith(2, ['C'])
+  })
+
+  it('propagates batched query errors to all pending callers', async () => {
+    dossiersRepository.queryByIds.mockRejectedValue(new Error('query failed'))
+
+    const firstRequest = dossiersService.queryByIds(['A'])
+    const secondRequest = dossiersService.queryByIds(['B'])
+
+    await expect(firstRequest).rejects.toThrow('query failed')
+    await expect(secondRequest).rejects.toThrow('query failed')
+    expect(dossiersRepository.queryByIds).toHaveBeenCalledTimes(1)
+    expect(dossiersRepository.queryByIds).toHaveBeenCalledWith(['A', 'B'])
+  })
+
+  it('returns empty array for empty query ids', async () => {
+    await expect(dossiersService.queryByIds([])).resolves.toEqual([])
+    expect(dossiersRepository.queryByIds).not.toHaveBeenCalled()
+  })
+
+  it('filters empty and duplicate ids before querying', async () => {
+    const recordA = createRecord('A')
+    dossiersRepository.queryByIds.mockResolvedValue([recordA])
+
+    await expect(dossiersService.queryByIds(['', 'A', 'A'])).resolves.toEqual([
+      recordA,
+    ])
+    expect(dossiersRepository.queryByIds).toHaveBeenCalledWith(['A'])
+  })
+
+  it('delegates searchSuggestions', async () => {
+    dossiersRepository.searchSuggestions.mockResolvedValue([suggestion])
+
+    await expect(dossiersService.searchSuggestions('test')).resolves.toEqual([
+      suggestion,
+    ])
+    expect(dossiersRepository.searchSuggestions).toHaveBeenCalledWith(
+      'test',
+      undefined,
+    )
+  })
+
+  it('delegates fetchAllDossiers', async () => {
+    const records = [createRecord('A')]
+    dossiersRepository.fetchAllDossiers.mockResolvedValue(records)
+
+    await expect(dossiersService.fetchAllDossiers()).resolves.toEqual(records)
+    expect(dossiersRepository.fetchAllDossiers).toHaveBeenCalledTimes(1)
+  })
+
+  it('delegates fetchFilteredDossiers', async () => {
+    const records = [createRecord('A')]
+    const filters = { genre: 'genre' }
+    dossiersRepository.fetchFilteredDossiers.mockResolvedValue(records)
+
+    await expect(
+      dossiersService.fetchFilteredDossiers(filters),
+    ).resolves.toEqual(records)
+    expect(dossiersRepository.fetchFilteredDossiers).toHaveBeenCalledWith(
+      filters,
+    )
+  })
 
   it('passes filters to searchSuggestions', async () => {
     const filters = { genre: 'Incantation', provenance: 'Babylon' }
-    dossiersRepository.searchSuggestions = jest
-      .fn()
-      .mockResolvedValue([suggestion])
+    dossiersRepository.searchSuggestions.mockResolvedValue([suggestion])
 
     const result = await dossiersService.searchSuggestions('test', filters)
 

--- a/src/dossiers/application/DossiersService.test.ts
+++ b/src/dossiers/application/DossiersService.test.ts
@@ -116,6 +116,24 @@ describe('DossiersService', () => {
     expect(dossiersRepository.queryByIds).not.toHaveBeenCalled()
   })
 
+  it('rejects pending queryByIds requests when auth scope changes before flush', async () => {
+    const authenticatedRecord = createRecord('A', 'authenticated')
+    dossiersRepository.queryByIds.mockResolvedValueOnce([authenticatedRecord])
+
+    const guestPendingRequest = dossiersService.queryByIds(['A'])
+
+    cacheScope = 'authenticated:user'
+
+    const authenticatedRequest = dossiersService.queryByIds(['A'])
+
+    await expect(guestPendingRequest).rejects.toThrow(
+      'DossiersService cache scope changed; pending queryByIds requests cancelled.',
+    )
+    await expect(authenticatedRequest).resolves.toEqual([authenticatedRecord])
+    expect(dossiersRepository.queryByIds).toHaveBeenCalledTimes(1)
+    expect(dossiersRepository.queryByIds).toHaveBeenCalledWith(['A'])
+  })
+
   it('does not leak in-flight query results into a new auth scope cache', async () => {
     const guestRecord = createRecord('A', 'guest')
     const authenticatedRecord = createRecord('A', 'authenticated')

--- a/src/dossiers/application/DossiersService.test.ts
+++ b/src/dossiers/application/DossiersService.test.ts
@@ -6,9 +6,8 @@ import DossiersService from 'dossiers/application/DossiersService'
 
 jest.mock('dossiers/infrastructure/DossiersRepository')
 
-const dossiersRepository = new (DossiersRepository as jest.Mock<
-  jest.Mocked<DossiersRepository>
->)()
+const dossiersRepository =
+  new (DossiersRepository as jest.Mock)() as jest.Mocked<DossiersRepository>
 
 const createRecord = (id: string): DossierRecord =>
   new DossierRecord({ _id: id })

--- a/src/dossiers/application/DossiersService.ts
+++ b/src/dossiers/application/DossiersService.ts
@@ -5,6 +5,7 @@ import DossierRecord, {
 import Bluebird from 'bluebird'
 
 const cacheEntryLifetimeInMilliseconds = 5 * 60 * 1000
+const defaultMaximumCachedDossiers = 250
 const defaultCacheScope = 'default'
 
 export interface DossiersSearch {
@@ -57,6 +58,7 @@ export default class DossiersService implements DossiersSearch {
     dossiersRepository: DossiersRepository,
     private readonly getCacheScope: () => string = () => defaultCacheScope,
     private readonly getCurrentTime: () => number = () => Date.now(),
+    private readonly maximumCachedDossiers: number = defaultMaximumCachedDossiers,
   ) {
     this.dossiersRepository = dossiersRepository
   }
@@ -144,12 +146,9 @@ export default class DossiersService implements DossiersSearch {
     }
 
     const requestGeneration = this.cacheGeneration
-    const recordsRequest =
-      idsToFetch.length === 0
-        ? Bluebird.resolve<readonly DossierRecord[]>([])
-        : this.dossiersRepository.queryByIds(idsToFetch)
-
-    pendingBatch.inFlightRequest = Bluebird.resolve(recordsRequest)
+    pendingBatch.inFlightRequest = Bluebird.resolve(
+      this.dossiersRepository.queryByIds(idsToFetch),
+    )
 
     pendingBatch.inFlightRequest
       .then((records) => {
@@ -216,10 +215,12 @@ export default class DossiersService implements DossiersSearch {
   }
 
   private setCachedDossier(record: DossierRecord): void {
+    this.cachedDossiersById.delete(record.id)
     this.cachedDossiersById.set(record.id, {
       value: record,
       expiresAt: this.getCurrentTime() + cacheEntryLifetimeInMilliseconds,
     })
+    this.trimCachedDossiers()
   }
 
   private hasFreshCachedDossier(id: string): boolean {
@@ -238,7 +239,22 @@ export default class DossiersService implements DossiersSearch {
       return null
     }
 
+    this.cachedDossiersById.delete(id)
+    this.cachedDossiersById.set(id, cacheEntry)
+
     return cacheEntry.value
+  }
+
+  private trimCachedDossiers(): void {
+    while (this.cachedDossiersById.size > this.maximumCachedDossiers) {
+      const oldestId = this.cachedDossiersById.keys().next().value
+
+      if (oldestId === undefined) {
+        return
+      }
+
+      this.cachedDossiersById.delete(oldestId)
+    }
   }
 
   private schedulePendingQueryByIdsFlush(

--- a/src/dossiers/application/DossiersService.ts
+++ b/src/dossiers/application/DossiersService.ts
@@ -4,6 +4,9 @@ import DossierRecord, {
 } from 'dossiers/domain/DossierRecord'
 import Bluebird from 'bluebird'
 
+const cacheEntryLifetimeInMilliseconds = 5 * 60 * 1000
+const defaultCacheScope = 'default'
+
 export interface DossiersSearch {
   queryByIds(query: string[]): Bluebird<readonly DossierRecord[]>
   searchSuggestions(
@@ -28,28 +31,46 @@ type PendingQueryByIdsRequest = {
   readonly reject: (error: unknown) => void
 }
 
+type CacheEntry<Value> = {
+  readonly value: Value
+  readonly expiresAt: number
+}
+
 type PendingQueryByIdsBatch = {
-  readonly ids: Set<string>
-  readonly requests: PendingQueryByIdsRequest[]
+  ids: Set<string>
+  requests: PendingQueryByIdsRequest[]
+  inFlightRequest: Bluebird<readonly DossierRecord[]> | null
+  flushScheduled: boolean
 }
 
 export default class DossiersService implements DossiersSearch {
   private readonly dossiersRepository: DossiersRepository
-  private readonly cachedDossiersById = new Map<string, DossierRecord>()
-  private pendingQueryByIdsBatch: PendingQueryByIdsBatch | null = null
+  private readonly cachedDossiersById = new Map<
+    string,
+    CacheEntry<DossierRecord>
+  >()
+  private pendingQueryByIdsBatch = this.createPendingQueryByIdsBatch()
+  private cacheScope: string | null = null
+  private cacheGeneration = 0
 
-  constructor(dossiersRepository: DossiersRepository) {
+  constructor(
+    dossiersRepository: DossiersRepository,
+    private readonly getCacheScope: () => string = () => defaultCacheScope,
+    private readonly getCurrentTime: () => number = () => Date.now(),
+  ) {
     this.dossiersRepository = dossiersRepository
   }
 
   queryByIds(query: string[]): Bluebird<readonly DossierRecord[]> {
+    this.clearCachesWhenScopeChanges()
+
     const ids = Array.from(new Set(query.filter((id) => id.length > 0)))
 
     if (ids.length === 0) {
       return Bluebird.resolve([])
     }
 
-    const missingIds = ids.filter((id) => !this.cachedDossiersById.has(id))
+    const missingIds = ids.filter((id) => !this.hasFreshCachedDossier(id))
 
     if (missingIds.length === 0) {
       return Bluebird.resolve(this.selectCachedDossiers(ids))
@@ -91,50 +112,71 @@ export default class DossiersService implements DossiersSearch {
     resolve: (records: readonly DossierRecord[]) => void,
     reject: (error: unknown) => void,
   ): void {
-    if (!this.pendingQueryByIdsBatch) {
-      this.pendingQueryByIdsBatch = {
-        ids: new Set<string>(),
-        requests: [],
-      }
-      queueMicrotask(() => this.flushPendingQueryByIdsBatch())
-    }
-
     const pendingBatch = this.pendingQueryByIdsBatch
-
-    if (!pendingBatch) {
-      return
-    }
 
     missingIds.forEach((id) => pendingBatch.ids.add(id))
     pendingBatch.requests.push({ ids, resolve, reject })
+    this.schedulePendingQueryByIdsFlush(pendingBatch)
   }
 
   private flushPendingQueryByIdsBatch(): void {
     const pendingBatch = this.pendingQueryByIdsBatch
-    this.pendingQueryByIdsBatch = null
 
-    if (!pendingBatch) {
+    if (pendingBatch.inFlightRequest) {
       return
     }
 
-    const idsToFetch = Array.from(pendingBatch.ids.values())
+    const idsToFetch = Array.from(pendingBatch.ids.values()).filter(
+      (id) => !this.hasFreshCachedDossier(id),
+    )
+    const requestsToResolve = pendingBatch.requests
+
+    pendingBatch.ids = new Set<string>()
+    pendingBatch.requests = []
+
+    if (requestsToResolve.length === 0) {
+      return
+    }
+
+    if (idsToFetch.length === 0) {
+      this.resolvePendingRequestsFromCache(requestsToResolve)
+      return
+    }
+
+    const requestGeneration = this.cacheGeneration
     const recordsRequest =
       idsToFetch.length === 0
         ? Bluebird.resolve<readonly DossierRecord[]>([])
         : this.dossiersRepository.queryByIds(idsToFetch)
 
-    Bluebird.resolve(recordsRequest)
+    pendingBatch.inFlightRequest = Bluebird.resolve(recordsRequest)
+
+    pendingBatch.inFlightRequest
       .then((records) => {
+        if (requestGeneration !== this.cacheGeneration) {
+          this.resolvePendingRequestsFromRecords(requestsToResolve, records)
+          return
+        }
+
         records.forEach((record) => {
-          this.cachedDossiersById.set(record.id, record)
+          this.setCachedDossier(record)
         })
 
-        pendingBatch.requests.forEach(({ ids, resolve }) =>
-          resolve(this.selectCachedDossiers(ids)),
-        )
+        this.resolvePendingRequestsFromCache(requestsToResolve)
       })
       .catch((error) => {
-        pendingBatch.requests.forEach(({ reject }) => reject(error))
+        requestsToResolve.forEach(({ reject }) => reject(error))
+      })
+      .finally(() => {
+        if (requestGeneration !== this.cacheGeneration) {
+          return
+        }
+
+        pendingBatch.inFlightRequest = null
+
+        if (pendingBatch.ids.size > 0 || pendingBatch.requests.length > 0) {
+          this.schedulePendingQueryByIdsFlush(pendingBatch)
+        }
       })
   }
 
@@ -142,8 +184,115 @@ export default class DossiersService implements DossiersSearch {
     ids: readonly string[],
   ): readonly DossierRecord[] {
     return ids.flatMap((id) => {
-      const record = this.cachedDossiersById.get(id)
+      const record = this.readCachedDossier(id)
       return record ? [record] : []
     })
+  }
+
+  private resolvePendingRequestsFromCache(
+    requests: readonly PendingQueryByIdsRequest[],
+  ): void {
+    requests.forEach(({ ids, resolve }) => {
+      resolve(this.selectCachedDossiers(ids))
+    })
+  }
+
+  private resolvePendingRequestsFromRecords(
+    requests: readonly PendingQueryByIdsRequest[],
+    records: readonly DossierRecord[],
+  ): void {
+    const recordsById = new Map<string, DossierRecord>(
+      records.map((record) => [record.id, record]),
+    )
+
+    requests.forEach(({ ids, resolve }) => {
+      resolve(
+        ids.flatMap((id) => {
+          const record = recordsById.get(id)
+          return record ? [record] : []
+        }),
+      )
+    })
+  }
+
+  private setCachedDossier(record: DossierRecord): void {
+    this.cachedDossiersById.set(record.id, {
+      value: record,
+      expiresAt: this.getCurrentTime() + cacheEntryLifetimeInMilliseconds,
+    })
+  }
+
+  private hasFreshCachedDossier(id: string): boolean {
+    return this.readCachedDossier(id) !== null
+  }
+
+  private readCachedDossier(id: string): DossierRecord | null {
+    const cacheEntry = this.cachedDossiersById.get(id)
+
+    if (!cacheEntry) {
+      return null
+    }
+
+    if (cacheEntry.expiresAt <= this.getCurrentTime()) {
+      this.cachedDossiersById.delete(id)
+      return null
+    }
+
+    return cacheEntry.value
+  }
+
+  private schedulePendingQueryByIdsFlush(
+    pendingBatch: PendingQueryByIdsBatch,
+  ): void {
+    if (pendingBatch.flushScheduled) {
+      return
+    }
+
+    pendingBatch.flushScheduled = true
+    queueMicrotask(() => {
+      if (this.pendingQueryByIdsBatch !== pendingBatch) {
+        return
+      }
+
+      pendingBatch.flushScheduled = false
+      this.flushPendingQueryByIdsBatch()
+    })
+  }
+
+  private clearAllCaches(): void {
+    this.cachedDossiersById.clear()
+    this.pendingQueryByIdsBatch = this.createPendingQueryByIdsBatch()
+    this.cacheGeneration += 1
+  }
+
+  private createPendingQueryByIdsBatch(): PendingQueryByIdsBatch {
+    return {
+      ids: new Set<string>(),
+      requests: [],
+      inFlightRequest: null,
+      flushScheduled: false,
+    }
+  }
+
+  private clearCachesWhenScopeChanges(): void {
+    const nextScope = this.resolveCacheScope()
+
+    if (this.cacheScope === null) {
+      this.cacheScope = nextScope
+      return
+    }
+
+    if (this.cacheScope !== nextScope) {
+      this.cacheScope = nextScope
+      this.clearAllCaches()
+    }
+  }
+
+  private resolveCacheScope(): string {
+    try {
+      return this.getCacheScope()
+    } catch {
+      return defaultCacheScope
+    }
   }
 }

--- a/src/dossiers/application/DossiersService.ts
+++ b/src/dossiers/application/DossiersService.ts
@@ -275,8 +275,16 @@ export default class DossiersService implements DossiersSearch {
 
   private clearAllCaches(): void {
     this.cachedDossiersById.clear()
+    const previousBatch = this.pendingQueryByIdsBatch
     this.pendingQueryByIdsBatch = this.createPendingQueryByIdsBatch()
     this.cacheGeneration += 1
+
+    if (previousBatch.requests.length > 0) {
+      const error = new Error(
+        'DossiersService cache scope changed; pending queryByIds requests cancelled.',
+      )
+      previousBatch.requests.forEach(({ reject }) => reject(error))
+    }
   }
 
   private createPendingQueryByIdsBatch(): PendingQueryByIdsBatch {

--- a/src/dossiers/application/DossiersService.ts
+++ b/src/dossiers/application/DossiersService.ts
@@ -38,8 +38,8 @@ export default class DossiersService implements DossiersSearch {
   private readonly cachedDossiersById = new Map<string, DossierRecord>()
   private pendingQueryByIdsBatch: PendingQueryByIdsBatch | null = null
 
-  constructor(afoRegisterRepository: DossiersRepository) {
-    this.dossiersRepository = afoRegisterRepository
+  constructor(dossiersRepository: DossiersRepository) {
+    this.dossiersRepository = dossiersRepository
   }
 
   queryByIds(query: string[]): Bluebird<readonly DossierRecord[]> {

--- a/src/dossiers/application/DossiersService.ts
+++ b/src/dossiers/application/DossiersService.ts
@@ -22,15 +22,44 @@ export interface DossiersSearch {
   }): Bluebird<readonly DossierRecord[]>
 }
 
+type PendingQueryByIdsRequest = {
+  readonly ids: readonly string[]
+  readonly resolve: (records: readonly DossierRecord[]) => void
+  readonly reject: (error: unknown) => void
+}
+
+type PendingQueryByIdsBatch = {
+  readonly ids: Set<string>
+  readonly requests: PendingQueryByIdsRequest[]
+}
+
 export default class DossiersService implements DossiersSearch {
   private readonly dossiersRepository: DossiersRepository
+  private readonly cachedDossiersById = new Map<string, DossierRecord>()
+  private pendingQueryByIdsBatch: PendingQueryByIdsBatch | null = null
 
   constructor(afoRegisterRepository: DossiersRepository) {
     this.dossiersRepository = afoRegisterRepository
   }
 
   queryByIds(query: string[]): Bluebird<readonly DossierRecord[]> {
-    return this.dossiersRepository.queryByIds(query)
+    const ids = Array.from(new Set(query.filter((id) => id.length > 0)))
+
+    if (ids.length === 0) {
+      return Bluebird.resolve([])
+    }
+
+    const missingIds = ids.filter((id) => !this.cachedDossiersById.has(id))
+
+    if (missingIds.length === 0) {
+      return Bluebird.resolve(this.selectCachedDossiers(ids))
+    }
+
+    return Bluebird.resolve(
+      new Promise<readonly DossierRecord[]>((resolve, reject) => {
+        this.addToPendingQueryByIdsBatch(ids, missingIds, resolve, reject)
+      }),
+    )
   }
 
   searchSuggestions(
@@ -54,5 +83,67 @@ export default class DossiersService implements DossiersSearch {
     genre?: string
   }): Bluebird<readonly DossierRecord[]> {
     return this.dossiersRepository.fetchFilteredDossiers(filters)
+  }
+
+  private addToPendingQueryByIdsBatch(
+    ids: readonly string[],
+    missingIds: readonly string[],
+    resolve: (records: readonly DossierRecord[]) => void,
+    reject: (error: unknown) => void,
+  ): void {
+    if (!this.pendingQueryByIdsBatch) {
+      this.pendingQueryByIdsBatch = {
+        ids: new Set<string>(),
+        requests: [],
+      }
+      queueMicrotask(() => this.flushPendingQueryByIdsBatch())
+    }
+
+    const pendingBatch = this.pendingQueryByIdsBatch
+
+    if (!pendingBatch) {
+      return
+    }
+
+    missingIds.forEach((id) => pendingBatch.ids.add(id))
+    pendingBatch.requests.push({ ids, resolve, reject })
+  }
+
+  private flushPendingQueryByIdsBatch(): void {
+    const pendingBatch = this.pendingQueryByIdsBatch
+    this.pendingQueryByIdsBatch = null
+
+    if (!pendingBatch) {
+      return
+    }
+
+    const idsToFetch = Array.from(pendingBatch.ids.values())
+    const recordsRequest =
+      idsToFetch.length === 0
+        ? Bluebird.resolve<readonly DossierRecord[]>([])
+        : this.dossiersRepository.queryByIds(idsToFetch)
+
+    Bluebird.resolve(recordsRequest)
+      .then((records) => {
+        records.forEach((record) => {
+          this.cachedDossiersById.set(record.id, record)
+        })
+
+        pendingBatch.requests.forEach(({ ids, resolve }) =>
+          resolve(this.selectCachedDossiers(ids)),
+        )
+      })
+      .catch((error) => {
+        pendingBatch.requests.forEach(({ reject }) => reject(error))
+      })
+  }
+
+  private selectCachedDossiers(
+    ids: readonly string[],
+  ): readonly DossierRecord[] {
+    return ids.flatMap((id) => {
+      const record = this.cachedDossiersById.get(id)
+      return record ? [record] : []
+    })
   }
 }

--- a/src/dossiers/application/DossiersService.ts
+++ b/src/dossiers/application/DossiersService.ts
@@ -78,11 +78,9 @@ export default class DossiersService implements DossiersSearch {
       return Bluebird.resolve(this.selectCachedDossiers(ids))
     }
 
-    return Bluebird.resolve(
-      new Promise<readonly DossierRecord[]>((resolve, reject) => {
-        this.addToPendingQueryByIdsBatch(ids, missingIds, resolve, reject)
-      }),
-    )
+    return new Bluebird<readonly DossierRecord[]>((resolve, reject) => {
+      this.addToPendingQueryByIdsBatch(ids, missingIds, resolve, reject)
+    })
   }
 
   searchSuggestions(
@@ -265,7 +263,7 @@ export default class DossiersService implements DossiersSearch {
     }
 
     pendingBatch.flushScheduled = true
-    queueMicrotask(() => {
+    Promise.resolve().then(() => {
       if (this.pendingQueryByIdsBatch !== pendingBatch) {
         return
       }

--- a/src/fragmentarium/application/FragmentService.test.ts
+++ b/src/fragmentarium/application/FragmentService.test.ts
@@ -1087,6 +1087,73 @@ describe('FragmentService cache', () => {
     expect(fragmentRepository.queryLatest).toHaveBeenCalledTimes(1)
   })
 
+  test('serves prefetched latest fragments without repository reads', async () => {
+    const queryResultWithPrefetchedFragment: QueryResult = {
+      items: [
+        {
+          museumNumber: number,
+          matchingLines: [1, 2, 3, 4],
+          matchCount: 1,
+          fragment: cachedFragment,
+        } as QueryResult['items'][number],
+      ],
+      matchCountTotal: 1,
+    }
+    fragmentRepository.queryLatest.mockReturnValue(
+      Promise.resolve(queryResultWithPrefetchedFragment),
+    )
+
+    await expect(service.queryLatest()).resolves.toEqual(
+      queryResultWithPrefetchedFragment,
+    )
+    await expect(service.find(number, [1, 2, 3], false)).resolves.toMatchObject(
+      {
+        number: cachedFragment.number,
+      },
+    )
+    await expect(service.find(number, [1, 2, 3], false)).resolves.toMatchObject(
+      {
+        number: cachedFragment.number,
+      },
+    )
+
+    expect(fragmentRepository.find).toHaveBeenCalledTimes(0)
+  })
+
+  test('falls back to repository reads when prefetched latest key does not match', async () => {
+    const queryResultWithPrefetchedFragment: QueryResult = {
+      items: [
+        {
+          museumNumber: number,
+          matchingLines: [8, 9],
+          matchCount: 1,
+          fragment: cachedFragment,
+        } as QueryResult['items'][number],
+      ],
+      matchCountTotal: 1,
+    }
+    fragmentRepository.queryLatest.mockReturnValue(
+      Promise.resolve(queryResultWithPrefetchedFragment),
+    )
+    fragmentRepository.find.mockReturnValue(Promise.resolve(updatedFragment))
+
+    await expect(service.queryLatest()).resolves.toEqual(
+      queryResultWithPrefetchedFragment,
+    )
+    await expect(service.find(number, [1, 2, 3], false)).resolves.toMatchObject(
+      {
+        number: updatedFragment.number,
+      },
+    )
+
+    expect(fragmentRepository.find).toHaveBeenCalledTimes(1)
+    expect(fragmentRepository.find).toHaveBeenCalledWith(
+      number,
+      [1, 2, 3],
+      false,
+    )
+  })
+
   test('does not cache completed query results', async () => {
     fragmentRepository.query.mockReturnValue(Promise.resolve(queryResult))
 

--- a/src/fragmentarium/application/FragmentService.test.ts
+++ b/src/fragmentarium/application/FragmentService.test.ts
@@ -1066,11 +1066,25 @@ describe('FragmentService cache', () => {
     expect(fragmentRepository.find).toHaveBeenCalledTimes(252)
   })
 
-  test('does not cache latest query results', async () => {
+  test('caches latest query results', async () => {
     fragmentRepository.queryLatest.mockReturnValue(Promise.resolve(queryResult))
 
     await expect(service.queryLatest()).resolves.toEqual(queryResult)
     await expect(service.queryLatest()).resolves.toEqual(queryResult)
+
+    expect(fragmentRepository.queryLatest).toHaveBeenCalledTimes(1)
+  })
+
+  test('refreshes expired latest query results', async () => {
+    fragmentRepository.queryLatest
+      .mockReturnValueOnce(Promise.resolve(queryResult))
+      .mockReturnValueOnce(Promise.resolve(updatedQueryResult))
+
+    await withExpiredCacheTimestamp(async (expireCache) => {
+      await expect(service.queryLatest()).resolves.toEqual(queryResult)
+      expireCache()
+      await expect(service.queryLatest()).resolves.toEqual(updatedQueryResult)
+    })
 
     expect(fragmentRepository.queryLatest).toHaveBeenCalledTimes(2)
   })
@@ -1154,13 +1168,51 @@ describe('FragmentService cache', () => {
     )
   })
 
-  test('does not cache completed query results', async () => {
+  test('caches completed query results', async () => {
     fragmentRepository.query.mockReturnValue(Promise.resolve(queryResult))
 
     await expect(service.query(query)).resolves.toEqual(queryResult)
     await expect(service.query(query)).resolves.toEqual(queryResult)
 
+    expect(fragmentRepository.query).toHaveBeenCalledTimes(1)
+  })
+
+  test('refreshes expired query results', async () => {
+    fragmentRepository.query
+      .mockReturnValueOnce(Promise.resolve(queryResult))
+      .mockReturnValueOnce(Promise.resolve(updatedQueryResult))
+
+    await withExpiredCacheTimestamp(async (expireCache) => {
+      await expect(service.query(query)).resolves.toEqual(queryResult)
+      expireCache()
+      await expect(service.query(query)).resolves.toEqual(updatedQueryResult)
+    })
+
     expect(fragmentRepository.query).toHaveBeenCalledTimes(2)
+  })
+
+  test('evicts oldest query cache entry when max size is exceeded', async () => {
+    fragmentRepository.query.mockImplementation(
+      (fragmentQuery: FragmentQuery) =>
+        Promise.resolve({
+          items: [
+            {
+              museumNumber: fragmentQuery.number ?? number,
+              matchingLines: [],
+              matchCount: 1,
+            },
+          ],
+          matchCountTotal: 1,
+        }),
+    )
+
+    for (let index = 0; index <= 250; index += 1) {
+      await service.query({ number: `K.${index}` })
+    }
+
+    await service.query({ number: 'K.0' })
+
+    expect(fragmentRepository.query).toHaveBeenCalledTimes(252)
   })
 
   test('shares in-flight query requests by stable query key', async () => {

--- a/src/fragmentarium/application/FragmentService.test.ts
+++ b/src/fragmentarium/application/FragmentService.test.ts
@@ -1134,6 +1134,43 @@ describe('FragmentService cache', () => {
     expect(fragmentRepository.find).toHaveBeenCalledTimes(0)
   })
 
+  test('stores prefetched latest fragments after cache scope changes', async () => {
+    let cacheScope = 'guest'
+    const scopedService = createScopedService(() => cacheScope)
+    const queryResultWithPrefetchedFragment: QueryResult = {
+      items: [
+        {
+          museumNumber: number,
+          matchingLines: [1, 2, 3, 4],
+          matchCount: 1,
+          fragment: updatedFragment,
+        } as QueryResult['items'][number],
+      ],
+      matchCountTotal: 1,
+    }
+    fragmentRepository.find.mockReturnValue(Promise.resolve(cachedFragment))
+    fragmentRepository.queryLatest.mockReturnValue(
+      Promise.resolve(queryResultWithPrefetchedFragment),
+    )
+
+    await expect(scopedService.find(number)).resolves.toMatchObject({
+      number: cachedFragment.number,
+    })
+
+    cacheScope = 'authenticated:user'
+
+    await expect(scopedService.queryLatest()).resolves.toEqual(
+      queryResultWithPrefetchedFragment,
+    )
+    await expect(
+      scopedService.find(number, [1, 2, 3], false),
+    ).resolves.toMatchObject({
+      number: updatedFragment.number,
+    })
+
+    expect(fragmentRepository.find).toHaveBeenCalledTimes(1)
+  })
+
   test('falls back to repository reads when prefetched latest key does not match', async () => {
     const queryResultWithPrefetchedFragment: QueryResult = {
       items: [

--- a/src/fragmentarium/application/FragmentService.test.ts
+++ b/src/fragmentarium/application/FragmentService.test.ts
@@ -1168,6 +1168,41 @@ describe('FragmentService cache', () => {
     )
   })
 
+  test('normalizes prefetched fragment errors using onError', async () => {
+    const queryResultWithPrefetchedFragment: QueryResult = {
+      items: [
+        {
+          museumNumber: number,
+          matchingLines: [1, 2, 3, 4],
+          matchCount: 1,
+          fragment: cachedFragment,
+        } as QueryResult['items'][number],
+      ],
+      matchCountTotal: 1,
+    }
+    const injectReferencesMock = jest
+      .spyOn(
+        service as unknown as {
+          injectReferences: (fragment: Fragment) => Promise<Fragment>
+        },
+        'injectReferences',
+      )
+      .mockReturnValue(Promise.reject(new Error('403 Forbidden')))
+    fragmentRepository.queryLatest.mockReturnValue(
+      Promise.resolve(queryResultWithPrefetchedFragment),
+    )
+
+    await expect(service.queryLatest()).resolves.toEqual(
+      queryResultWithPrefetchedFragment,
+    )
+    await expect(service.find(number, [1, 2, 3], false)).rejects.toThrow(
+      "You don't have permissions to view this fragment.",
+    )
+
+    expect(fragmentRepository.find).toHaveBeenCalledTimes(0)
+    injectReferencesMock.mockRestore()
+  })
+
   test('caches completed query results', async () => {
     fragmentRepository.query.mockReturnValue(Promise.resolve(queryResult))
 
@@ -1658,6 +1693,55 @@ describe('FragmentService cache', () => {
     await expect(inFlightLatestQuery).resolves.toEqual(queryResult)
     await expect(service.queryLatest()).resolves.toEqual(updatedQueryResult)
     expect(fragmentRepository.queryLatest).toHaveBeenCalledTimes(2)
+  })
+
+  test('does not repopulate prefetched latest fragments from stale latest query after update', async () => {
+    let resolveStaleLatestQuery: (value: QueryResult) => void = () => undefined
+    const staleLatestQuery = new Promise<QueryResult>((resolve) => {
+      resolveStaleLatestQuery = resolve
+    })
+    const staleLatestQueryResult: QueryResult = {
+      items: [
+        {
+          museumNumber: number,
+          matchingLines: [1, 2, 3, 4],
+          matchCount: 1,
+          fragment: cachedFragment,
+        } as QueryResult['items'][number],
+      ],
+      matchCountTotal: 1,
+    }
+
+    fragmentRepository.queryLatest
+      .mockReturnValueOnce(staleLatestQuery)
+      .mockReturnValueOnce(Promise.resolve(updatedQueryResult))
+    fragmentRepository.find.mockReturnValue(Promise.resolve(updatedFragment))
+    fragmentRepository.updateEdition.mockReturnValue(
+      Promise.resolve(updatedFragment),
+    )
+
+    const inFlightLatestQuery = service.queryLatest()
+    await expect(service.updateEdition(number, edition)).resolves.toMatchObject(
+      {
+        number: updatedFragment.number,
+      },
+    )
+    await expect(service.queryLatest()).resolves.toEqual(updatedQueryResult)
+
+    resolveStaleLatestQuery(staleLatestQueryResult)
+
+    await expect(inFlightLatestQuery).resolves.toEqual(staleLatestQueryResult)
+    await expect(service.find(number, [1, 2, 3], false)).resolves.toMatchObject(
+      {
+        number: updatedFragment.number,
+      },
+    )
+    expect(fragmentRepository.find).toHaveBeenCalledTimes(1)
+    expect(fragmentRepository.find).toHaveBeenCalledWith(
+      number,
+      [1, 2, 3],
+      false,
+    )
   })
 
   test('evicts oldest provenance by id cache entry when max size is exceeded', async () => {

--- a/src/fragmentarium/application/FragmentService.ts
+++ b/src/fragmentarium/application/FragmentService.ts
@@ -58,6 +58,10 @@ type CacheEntry<CacheValue> = {
   readonly value: CacheValue
 }
 
+type QueryItemWithPrefetchedFragment = QueryResult['items'][number] & {
+  readonly fragment?: Fragment
+}
+
 export type ThumbnailSize = 'small' | 'medium' | 'large'
 
 export const onError = (error) => {
@@ -205,6 +209,7 @@ export class FragmentService {
     string,
     Bluebird<QueryResult>
   >()
+  private readonly prefetchedLatestFragments = new Map<string, Fragment>()
   private readonly cachedThumbnails = new Map<
     string,
     CacheEntry<ThumbnailBlob>
@@ -248,11 +253,7 @@ export class FragmentService {
       this.cachedFragmentRequests,
       cacheKey,
       maximumCachedFragments,
-      () =>
-        this.fragmentRepository
-          .find(number, lines, excludeLines)
-          .then((fragment: Fragment) => this.injectReferences(fragment))
-          .catch(onError),
+      () => this.findAndInjectFragment(number, lines, excludeLines, cacheKey),
     )
   }
 
@@ -545,7 +546,11 @@ export class FragmentService {
     return this.getOrFetchInFlightRequest(
       this.cachedQueryResultRequests,
       latestQueryCacheKey,
-      () => this.fragmentRepository.queryLatest(),
+      () =>
+        this.fragmentRepository.queryLatest().then((queryResult) => {
+          this.storePrefetchedLatestFragments(queryResult)
+          return queryResult
+        }),
     )
   }
 
@@ -559,6 +564,72 @@ export class FragmentService {
 
   collectLemmaSuggestions(number: string): Bluebird<LemmaSuggestions> {
     return this.fragmentRepository.collectLemmaSuggestions(number)
+  }
+
+  private findAndInjectFragment(
+    number: string,
+    lines: readonly number[] | undefined,
+    excludeLines: boolean | undefined,
+    cacheKey: string,
+  ): Bluebird<Fragment> {
+    const prefetchedFragment = this.takePrefetchedLatestFragment(cacheKey)
+
+    if (prefetchedFragment) {
+      return this.injectReferences(prefetchedFragment)
+    }
+
+    return this.fragmentRepository
+      .find(number, lines, excludeLines)
+      .then((fragment: Fragment) => this.injectReferences(fragment))
+      .catch(onError)
+  }
+
+  private storePrefetchedLatestFragments(queryResult: QueryResult): void {
+    this.prefetchedLatestFragments.clear()
+
+    queryResult.items.forEach((queryItem) => {
+      const prefetchedFragment = this.readPrefetchedLatestFragment(queryItem)
+
+      if (!prefetchedFragment) {
+        return
+      }
+
+      const lines = _.take(queryItem.matchingLines, 3)
+      const excludeLines = _.isEmpty(queryItem.matchingLines)
+
+      this.prefetchedLatestFragments.set(
+        this.createFragmentCacheKey(
+          queryItem.museumNumber,
+          lines,
+          excludeLines,
+        ),
+        prefetchedFragment,
+      )
+      this.prefetchedLatestFragments.set(
+        this.createFragmentCacheKey(queryItem.museumNumber),
+        prefetchedFragment,
+      )
+    })
+  }
+
+  private readPrefetchedLatestFragment(
+    queryItem: QueryResult['items'][number],
+  ): Fragment | null {
+    const prefetchedFragment = (queryItem as QueryItemWithPrefetchedFragment)
+      .fragment
+
+    return prefetchedFragment ?? null
+  }
+
+  private takePrefetchedLatestFragment(cacheKey: string): Fragment | null {
+    const prefetchedFragment = this.prefetchedLatestFragments.get(cacheKey)
+
+    if (!prefetchedFragment) {
+      return null
+    }
+
+    this.prefetchedLatestFragments.delete(cacheKey)
+    return prefetchedFragment
   }
 
   private injectReferences(fragment: Fragment): Bluebird<Fragment> {
@@ -734,6 +805,7 @@ export class FragmentService {
 
   private clearCachedQueryResults(): void {
     this.cachedQueryResultRequests.clear()
+    this.prefetchedLatestFragments.clear()
   }
 
   private clearAllCaches(): void {
@@ -746,6 +818,7 @@ export class FragmentService {
     this.cachedFragments.clear()
     this.cachedFragmentRequests.clear()
     this.cachedQueryResultRequests.clear()
+    this.prefetchedLatestFragments.clear()
     this.cachedThumbnails.clear()
     this.cachedThumbnailRequests.clear()
   }

--- a/src/fragmentarium/application/FragmentService.ts
+++ b/src/fragmentarium/application/FragmentService.ts
@@ -177,6 +177,7 @@ export interface AnnotationRepository {
 export class FragmentService {
   private readonly referenceInjector: ReferenceInjector
   private cacheScope: string | null = null
+  private cacheGeneration = 0
   private readonly cachedProvenances = new Map<
     string,
     CacheEntry<readonly ProvenanceRecord[]>
@@ -550,6 +551,8 @@ export class FragmentService {
   }
 
   queryLatest(): Bluebird<QueryResult> {
+    const queryGeneration = this.cacheGeneration
+
     return this.getOrFetchCachedValue(
       this.cachedQueryResults,
       this.cachedQueryResultRequests,
@@ -557,7 +560,9 @@ export class FragmentService {
       maximumCachedQueryResults,
       () => this.fragmentRepository.queryLatest(),
     ).then((queryResult) => {
-      this.storePrefetchedLatestFragments(queryResult)
+      if (queryGeneration === this.cacheGeneration) {
+        this.storePrefetchedLatestFragments(queryResult)
+      }
       return queryResult
     })
   }
@@ -583,7 +588,7 @@ export class FragmentService {
     const prefetchedFragment = this.takePrefetchedLatestFragment(cacheKey)
 
     if (prefetchedFragment) {
-      return this.injectReferences(prefetchedFragment)
+      return this.injectReferences(prefetchedFragment).catch(onError)
     }
 
     return this.fragmentRepository
@@ -815,6 +820,7 @@ export class FragmentService {
     this.cachedQueryResults.clear()
     this.cachedQueryResultRequests.clear()
     this.prefetchedLatestFragments.clear()
+    this.cacheGeneration += 1
   }
 
   private clearAllCaches(): void {
@@ -831,6 +837,7 @@ export class FragmentService {
     this.prefetchedLatestFragments.clear()
     this.cachedThumbnails.clear()
     this.cachedThumbnailRequests.clear()
+    this.cacheGeneration += 1
   }
 
   private clearCachesWhenScopeChanges(): void {

--- a/src/fragmentarium/application/FragmentService.ts
+++ b/src/fragmentarium/application/FragmentService.ts
@@ -551,15 +551,16 @@ export class FragmentService {
   }
 
   queryLatest(): Bluebird<QueryResult> {
-    const queryGeneration = this.cacheGeneration
-
-    return this.getOrFetchCachedValue(
+    const queryResultRequest = this.getOrFetchCachedValue(
       this.cachedQueryResults,
       this.cachedQueryResultRequests,
       latestQueryCacheKey,
       maximumCachedQueryResults,
       () => this.fragmentRepository.queryLatest(),
-    ).then((queryResult) => {
+    )
+    const queryGeneration = this.cacheGeneration
+
+    return queryResultRequest.then((queryResult) => {
       if (queryGeneration === this.cacheGeneration) {
         this.storePrefetchedLatestFragments(queryResult)
       }

--- a/src/fragmentarium/application/FragmentService.ts
+++ b/src/fragmentarium/application/FragmentService.ts
@@ -49,6 +49,7 @@ const maximumCachedFragments = 250
 const maximumCachedThumbnails = 250
 const maximumCachedProvenanceRecords = 250
 const maximumCachedProvenanceChildren = 250
+const maximumCachedQueryResults = 250
 const latestQueryCacheKey = 'latest:'
 const provenanceCacheKey = 'provenance:'
 const defaultCacheScope = 'default'
@@ -204,6 +205,10 @@ export class FragmentService {
   private readonly cachedFragmentRequests = new Map<
     string,
     Bluebird<Fragment>
+  >()
+  private readonly cachedQueryResults = new Map<
+    string,
+    CacheEntry<QueryResult>
   >()
   private readonly cachedQueryResultRequests = new Map<
     string,
@@ -535,23 +540,26 @@ export class FragmentService {
 
   query(fragmentQuery: FragmentQuery): Bluebird<QueryResult> {
     const cacheKey = this.createQueryCacheKey(fragmentQuery)
-    return this.getOrFetchInFlightRequest(
+    return this.getOrFetchCachedValue(
+      this.cachedQueryResults,
       this.cachedQueryResultRequests,
       cacheKey,
+      maximumCachedQueryResults,
       () => this.fragmentRepository.query(fragmentQuery),
     )
   }
 
   queryLatest(): Bluebird<QueryResult> {
-    return this.getOrFetchInFlightRequest(
+    return this.getOrFetchCachedValue(
+      this.cachedQueryResults,
       this.cachedQueryResultRequests,
       latestQueryCacheKey,
-      () =>
-        this.fragmentRepository.queryLatest().then((queryResult) => {
-          this.storePrefetchedLatestFragments(queryResult)
-          return queryResult
-        }),
-    )
+      maximumCachedQueryResults,
+      () => this.fragmentRepository.queryLatest(),
+    ).then((queryResult) => {
+      this.storePrefetchedLatestFragments(queryResult)
+      return queryResult
+    })
   }
 
   queryByTraditionalReferences(
@@ -804,6 +812,7 @@ export class FragmentService {
   }
 
   private clearCachedQueryResults(): void {
+    this.cachedQueryResults.clear()
     this.cachedQueryResultRequests.clear()
     this.prefetchedLatestFragments.clear()
   }
@@ -817,6 +826,7 @@ export class FragmentService {
     this.cachedProvenanceChildrenByIdRequest.clear()
     this.cachedFragments.clear()
     this.cachedFragmentRequests.clear()
+    this.cachedQueryResults.clear()
     this.cachedQueryResultRequests.clear()
     this.prefetchedLatestFragments.clear()
     this.cachedThumbnails.clear()

--- a/src/fragmentarium/infrastructure/FragmentRepository.test.ts
+++ b/src/fragmentarium/infrastructure/FragmentRepository.test.ts
@@ -424,6 +424,65 @@ const queryTestData: TestData<FragmentRepository>[] = queryTestCases.map(
 describe('Query FragmentRepository', () =>
   testDelegation(fragmentRepository, queryTestData))
 
+describe('FragmentRepository queryLatest', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('maps latest query result', async () => {
+    apiClient.fetchJson.mockResolvedValueOnce(queryResultDto)
+
+    await expect(fragmentRepository.queryLatest()).resolves.toEqual(queryResult)
+    expect(apiClient.fetchJson).toHaveBeenCalledWith('/fragments/latest', false)
+  })
+
+  it('maps prefetched fragment from query item payload', async () => {
+    apiClient.fetchJson.mockResolvedValueOnce({
+      matchCountTotal: 1,
+      items: [
+        {
+          museumNumber: fragmentDto.museumNumber,
+          matchingLines: [],
+          matchCount: 0,
+          fragment: fragmentDto,
+        },
+      ],
+    })
+
+    const latestQueryResult = await fragmentRepository.queryLatest()
+    const latestQueryItem = latestQueryResult.items[0] as {
+      museumNumber: string
+      fragment?: { number: string }
+    }
+
+    expect(latestQueryItem.museumNumber).toEqual(fragment.number)
+    expect(latestQueryItem.fragment?.number).toEqual(fragment.number)
+  })
+
+  it('maps prefetched fragment from top-level fragments payload', async () => {
+    apiClient.fetchJson.mockResolvedValueOnce({
+      matchCountTotal: 1,
+      items: [
+        {
+          museumNumber: fragmentDto.museumNumber,
+          matchingLines: [],
+          matchCount: 0,
+        },
+      ],
+      fragments: [fragmentDto],
+    })
+
+    const latestQueryResult = await fragmentRepository.queryLatest()
+    const latestQueryItem = latestQueryResult.items[0] as {
+      museumNumber: string
+      fragment?: { number: string }
+    }
+
+    expect(latestQueryItem.museumNumber).toEqual(fragment.number)
+    expect(latestQueryItem.fragment?.number).toEqual(fragment.number)
+  })
+})
+
 const queryByTraditionalReferencesTestData: TestData<FragmentRepository>[] = [
   new TestData(
     'queryByTraditionalReferences',

--- a/src/fragmentarium/infrastructure/FragmentRepository.ts
+++ b/src/fragmentarium/infrastructure/FragmentRepository.ts
@@ -157,17 +157,66 @@ function createFragmentPath(number: string, ...subResources: string[]): string {
   return ['/fragments', encodeURIComponent(number), ...subResources].join('/')
 }
 
-function createQueryItem(dto): QueryItem {
+type QueryItemDto = {
+  museumNumber: {
+    prefix: string
+    number: string
+    suffix: string
+  }
+  matchingLines: readonly number[]
+  matchCount: number
+}
+
+type LatestQueryItemDto = QueryItemDto & {
+  fragment?: FragmentDto
+}
+
+type LatestQueryResultDto = {
+  items: readonly LatestQueryItemDto[]
+  matchCountTotal: number
+  fragments?: readonly FragmentDto[]
+}
+
+type QueryResultDto = {
+  items: readonly QueryItemDto[]
+  matchCountTotal: number
+}
+
+function createQueryItem(dto: QueryItemDto): QueryItem {
   return {
-    ...dto,
     museumNumber: museumNumberToString(dto.museumNumber),
+    matchingLines: dto.matchingLines,
+    matchCount: dto.matchCount,
   }
 }
 
-function createQueryResult(dto): QueryResult {
+function createQueryResult(dto: QueryResultDto): QueryResult {
   return {
     matchCountTotal: dto.matchCountTotal,
     items: dto.items.map(createQueryItem),
+  }
+}
+
+function createLatestQueryResult(dto: LatestQueryResultDto): QueryResult {
+  const fragmentsByMuseumNumber = new Map<string, Fragment>(
+    (dto.fragments ?? []).map((fragmentDto) => {
+      const fragment = createFragment(fragmentDto)
+      return [fragment.number, fragment]
+    }),
+  )
+
+  return {
+    matchCountTotal: dto.matchCountTotal,
+    items: dto.items.map((itemDto) => {
+      const queryItem = createQueryItem(itemDto)
+      const prefetchedFragment = itemDto.fragment
+        ? createFragment(itemDto.fragment)
+        : fragmentsByMuseumNumber.get(queryItem.museumNumber)
+
+      return prefetchedFragment
+        ? { ...queryItem, fragment: prefetchedFragment }
+        : queryItem
+    }),
   }
 }
 
@@ -483,7 +532,7 @@ class ApiFragmentRepository
 
   query(fragmentQuery: FragmentQuery): Promise<QueryResult> {
     return this.apiClient
-      .fetchJson<QueryResult>(
+      .fetchJson<QueryResultDto>(
         `/fragments/query?${stringify(fragmentQuery)}`,
         false,
       )
@@ -492,8 +541,8 @@ class ApiFragmentRepository
 
   queryLatest(): Promise<QueryResult> {
     return this.apiClient
-      .fetchJson<QueryResult>('/fragments/latest', false)
-      .then(createQueryResult)
+      .fetchJson<LatestQueryResultDto>('/fragments/latest', false)
+      .then(createLatestQueryResult)
   }
 
   queryByTraditionalReferences(


### PR DESCRIPTION
Need to reduce API calls done during first-load for library. Addressing fan-out in library by collapsing N+1 calls and adding batch requests for dossiers. Moved some caching from client-side to server side