### PR TITLE
dev: added optimization & tests

### DIFF
--- a/src/common/utils/getOrFetchCachedValue.ts
+++ b/src/common/utils/getOrFetchCachedValue.ts
@@ -29,7 +29,11 @@ export default function getOrFetchCachedValue<CacheKey, CacheValue>({
   const inFlightRequest = requests.get(key)
 
   if (inFlightRequest) {
-    return inFlightRequest
+    if (inFlightRequest.isCancelled()) {
+      requests.delete(key)
+    } else {
+      return inFlightRequest
+    }
   }
 
   const requestReference: { current?: Bluebird<CacheValue> } = {}

--- a/src/corpus/ui/search/CorpusSearchResult.tsx
+++ b/src/corpus/ui/search/CorpusSearchResult.tsx
@@ -181,15 +181,21 @@ export const CorpusSearchResult = withData<
 >(
   ({ data, textService, corpusQuery }): JSX.Element => {
     const chapterCount = data.items.length
+    const matchCountTotal = data.matchCountTotal
+    const hasLineCount = typeof matchCountTotal === 'number'
+    const lineCountInfo = hasLineCount
+      ? `${data.isMatchCountTotalExact === false ? 'about ' : ''}${matchCountTotal.toLocaleString()} line${
+          matchCountTotal === 1 ? '' : 's'
+        } in `
+      : ''
     return (
       <>
         <Row>
           <Col className="justify-content-center fragment-result__match-info">
-            {`Found ${data.matchCountTotal.toLocaleString()} line${
-              data.matchCountTotal === 1 ? '' : 's'
-            } in ${chapterCount.toLocaleString()} chapter${
+            {`Found ${lineCountInfo}${chapterCount.toLocaleString()} chapter${
               chapterCount === 1 ? '' : 's'
             }`}
+            {data.hasNextPage === true && '; more results are available'}
           </Col>
         </Row>
 

--- a/src/dictionary/ui/search/CorpusLemmaLines.tsx
+++ b/src/dictionary/ui/search/CorpusLemmaLines.tsx
@@ -50,12 +50,26 @@ export default withData<
   CorpusQueryResult
 >(
   ({ data, textService, lemmaId }): JSX.Element => {
-    const total = data.matchCountTotal.toLocaleString()
-    const hasMatches = data.matchCountTotal > 0
+    const matchCountTotal = data.matchCountTotal
+    const hasMatchCount = typeof matchCountTotal === 'number'
+    const total = hasMatchCount ? matchCountTotal.toLocaleString() : null
+    const hasMatches = hasMatchCount
+      ? matchCountTotal > 0
+      : data.items.length > 0
     return (
       <>
         <p>
-          {total} matches&nbsp;
+          {hasMatchCount ? (
+            <>
+              {data.isMatchCountTotalExact === false && 'About '}
+              {total} matches&nbsp;
+            </>
+          ) : (
+            <>
+              Matches found in {data.items.length.toLocaleString()} Corpus
+              chapter{data.items.length === 1 ? '' : 's'}&nbsp;
+            </>
+          )}
           {hasMatches && (
             <LemmaQueryLink lemmaId={lemmaId} anchor={'#corpus'} />
           )}
@@ -64,7 +78,11 @@ export default withData<
         {hasMatches && (
           <p>
             <LemmaQueryLink lemmaId={lemmaId} anchor={'#corpus'}>
-              Show all {total} matches in Corpus search&nbsp;
+              {hasMatchCount && data.isMatchCountTotalExact !== false ? (
+                <>Show all {total} matches in Corpus search&nbsp;</>
+              ) : (
+                <>Show matches in Corpus search&nbsp;</>
+              )}
             </LemmaQueryLink>
           </p>
         )}

--- a/src/dictionary/ui/search/FragmentLemmaLines.test.tsx
+++ b/src/dictionary/ui/search/FragmentLemmaLines.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import FragmentService from 'fragmentarium/application/FragmentService'
 import { render, screen } from '@testing-library/react'
 import { dictionaryWord } from 'test-support/word-info-fixtures'
-import FragmentLemmaLines from './FragmentLemmaLines'
+import FragmentLemmaLines, { RenderFragmentLines } from './FragmentLemmaLines'
 import { fragment, lines } from 'test-support/test-fragment'
 import { QueryItem, QueryResult } from 'query/QueryResult'
 import Bluebird from 'bluebird'
@@ -14,9 +14,14 @@ import { produce, castDraft, Draft } from 'immer'
 import { Text } from 'transliteration/domain/text'
 import { TextLine, TextLineDto } from 'transliteration/domain/text-line'
 import { atfTokenKur } from 'test-support/test-tokens'
+import { lineNumberFactory } from 'test-support/linenumber-factory'
 
 jest.mock('fragmentarium/application/FragmentService')
 jest.mock('dictionary/application/WordService')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
 
 const word = { ...dictionaryWord, _id: 'testWordId' }
 
@@ -35,6 +40,21 @@ const text = new Text({
 
 const fragmentWithLemma = produce(fragment, (draft: Draft<Fragment>) => {
   draft.text = castDraft(text)
+})
+
+const previewSubsetText = new Text({
+  lines: [
+    new TextLine(lineDto),
+    new TextLine({
+      ...lines[1],
+      prefix: '2.',
+      lineNumber: lineNumberFactory.build({ number: 2 }),
+    }),
+  ],
+})
+
+const previewSubsetFragment = produce(fragment, (draft: Draft<Fragment>) => {
+  draft.text = castDraft(previewSubsetText)
 })
 
 let container: HTMLElement
@@ -79,5 +99,26 @@ describe('Show Library entries', () => {
     await screen.findByText(fragmentWithLemma.number)
     await screen.findByText('kur')
     expect(container).toMatchSnapshot()
+  })
+})
+
+describe('RenderFragmentLines', () => {
+  it('renders the preview subset without hydrating the fragment', () => {
+    render(
+      <MemoryRouter>
+        <DictionaryContext.Provider value={wordService}>
+          <RenderFragmentLines
+            fragment={previewSubsetFragment}
+            lemmaIds={[word._id]}
+            linesToShow={3}
+            totalLines={5}
+          />
+        </DictionaryContext.Provider>
+      </MemoryRouter>,
+    )
+
+    expect(fragmentService.find).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'kur' })).toBeVisible()
+    expect(screen.getByText('And 2 more')).toBeVisible()
   })
 })

--- a/src/dictionary/ui/search/FragmentLemmaLines.test.tsx
+++ b/src/dictionary/ui/search/FragmentLemmaLines.test.tsx
@@ -100,6 +100,25 @@ describe('Show Library entries', () => {
     await screen.findByText('kur')
     expect(container).toMatchSnapshot()
   })
+
+  it('renders a document-count fallback when matchCountTotal is null', async () => {
+    const queryItem: QueryItem = {
+      museumNumber: 'Test.Fragment',
+      matchingLines: [0],
+      matchCount: 1,
+    }
+    fragmentService.query.mockReturnValue(
+      Bluebird.resolve({ items: [queryItem], matchCountTotal: null }),
+    )
+    fragmentService.find.mockReturnValue(Bluebird.resolve(fragmentWithLemma))
+
+    renderFragmentLemmaLines()
+
+    expect(
+      await screen.findByText('Matches found in 1 Library document'),
+    ).toBeVisible()
+    expect(screen.queryByText('0 matches')).not.toBeInTheDocument()
+  })
 })
 
 describe('RenderFragmentLines', () => {

--- a/src/dictionary/ui/search/FragmentLemmaLines.tsx
+++ b/src/dictionary/ui/search/FragmentLemmaLines.tsx
@@ -136,13 +136,29 @@ export default withData<
   QueryResult
 >(
   ({ data: queryResult, fragmentService, lemmaId }): JSX.Element => {
-    const total = queryResult.matchCountTotal.toLocaleString()
-    const hasMatches = queryResult.matchCountTotal > 0
+    const hasMatchCount = typeof queryResult.matchCountTotal === 'number'
+    const total = hasMatchCount
+      ? queryResult.matchCountTotal.toLocaleString()
+      : null
+    const hasMatches = hasMatchCount
+      ? queryResult.matchCountTotal > 0
+      : queryResult.items.length > 0
 
     return (
       <>
         <p>
-          {total} matches&nbsp;
+          {hasMatchCount ? (
+            <>
+              {queryResult.isMatchCountTotalExact === false && 'About '}
+              {total} matches&nbsp;
+            </>
+          ) : (
+            <>
+              Matches found in {queryResult.items.length.toLocaleString()}{' '}
+              Library document{queryResult.items.length === 1 ? '' : 's'}
+              &nbsp;
+            </>
+          )}
           {hasMatches && <LemmaQueryLink lemmaId={lemmaId} />}
         </p>
         <FragmentLemmaLines
@@ -152,7 +168,11 @@ export default withData<
         />
         {hasMatches && (
           <LemmaQueryLink lemmaId={lemmaId}>
-            Show all {total} matches in Library search&nbsp;
+            {hasMatchCount && queryResult.isMatchCountTotalExact !== false ? (
+              <>Show all {total} matches in Library search&nbsp;</>
+            ) : (
+              <>Show matches in Library search&nbsp;</>
+            )}
           </LemmaQueryLink>
         )}
       </>

--- a/src/dossiers/ui/DossiersDisplay.test.tsx
+++ b/src/dossiers/ui/DossiersDisplay.test.tsx
@@ -135,4 +135,68 @@ describe('withData HOC integration', () => {
     await screen.findByText(/Test description/)
     expect(mockDossiersService.queryByIds).toHaveBeenCalledWith(['test'])
   })
+
+  it('does not refetch when dossier IDs are unchanged but object references change', async () => {
+    const queryByIds = jest.fn().mockResolvedValue([mockRecord])
+    const mockDossiersService = { queryByIds }
+    const fragmentA = fragmentFactory.build({
+      dossiers: [{ dossierId: 'test' }],
+    })
+
+    const { rerender } = render(
+      <FragmentDossierRecordsDisplay
+        dossiersService={mockDossiersService as unknown as DossiersService}
+        fragment={fragmentA as Fragment}
+      />,
+    )
+
+    await screen.findByRole('button', { name: /test/ })
+    expect(queryByIds).toHaveBeenCalledTimes(1)
+
+    const fragmentB = fragmentFactory.build({
+      dossiers: [{ dossierId: 'test' }],
+    })
+
+    rerender(
+      <FragmentDossierRecordsDisplay
+        dossiersService={mockDossiersService as unknown as DossiersService}
+        fragment={fragmentB as Fragment}
+      />,
+    )
+
+    expect(queryByIds).toHaveBeenCalledTimes(1)
+  })
+
+  it('refetches when dossier IDs change', async () => {
+    const queryByIds = jest.fn().mockResolvedValue([mockRecord])
+    const mockDossiersService = { queryByIds }
+    const fragmentA = fragmentFactory.build({
+      dossiers: [{ dossierId: 'test' }],
+    })
+
+    const { rerender } = render(
+      <FragmentDossierRecordsDisplay
+        dossiersService={mockDossiersService as unknown as DossiersService}
+        fragment={fragmentA as Fragment}
+      />,
+    )
+
+    await screen.findByRole('button', { name: /test/ })
+    expect(queryByIds).toHaveBeenCalledTimes(1)
+
+    const fragmentB = fragmentFactory.build({
+      dossiers: [{ dossierId: 'other' }],
+    })
+
+    rerender(
+      <FragmentDossierRecordsDisplay
+        dossiersService={mockDossiersService as unknown as DossiersService}
+        fragment={fragmentB as Fragment}
+      />,
+    )
+
+    await screen.findByRole('button', { name: /test/ })
+    expect(queryByIds).toHaveBeenCalledTimes(2)
+    expect(queryByIds).toHaveBeenCalledWith(['other'])
+  })
 })

--- a/src/dossiers/ui/DossiersDisplay.tsx
+++ b/src/dossiers/ui/DossiersDisplay.tsx
@@ -200,7 +200,9 @@ const FragmentDossierRecordsDisplay = withData<
     )
   },
   {
-    watch: (props) => [...props.fragment.dossiers],
+    watch: (props) => [
+      props.fragment.dossiers.map((dossier) => dossier.dossierId).join('|'),
+    ],
     filter: (props) => !_.isEmpty(props.fragment.dossiers),
     defaultData: () => ({ records: [] }),
   },

--- a/src/fragmentarium/application/FragmentService.test.ts
+++ b/src/fragmentarium/application/FragmentService.test.ts
@@ -1328,6 +1328,24 @@ describe('FragmentService cache', () => {
     expect(fragmentRepository.query).toHaveBeenCalledTimes(1)
   })
 
+  test('does not return cancelled in-flight query when re-requested', async () => {
+    const deferredQuery = new Promise<QueryResult>(() => {})
+
+    fragmentRepository.query
+      .mockReturnValueOnce(deferredQuery)
+      .mockReturnValueOnce(Promise.resolve(updatedQueryResult))
+
+    const firstQuery = service.query(query)
+
+    firstQuery.cancel()
+
+    const secondQuery = service.query(query)
+
+    await expect(secondQuery).resolves.toEqual(updatedQueryResult)
+
+    expect(fragmentRepository.query).toHaveBeenCalledTimes(2)
+  })
+
   test('caches thumbnails by fragment number and size', async () => {
     const thumbnail = { blob: null }
     imageRepository.findThumbnail.mockReturnValue(Promise.resolve(thumbnail))

--- a/src/fragmentarium/application/FragmentService.ts
+++ b/src/fragmentarium/application/FragmentService.ts
@@ -59,9 +59,7 @@ const latestQueryCacheKey = 'latest:'
 const provenanceCacheKey = 'provenance:'
 const defaultCacheScope = 'default'
 
-type QueryItemWithPrefetchedFragment = QueryResult['items'][number] & {
-  readonly fragment?: Fragment
-}
+type QueryItemWithPrefetchedFragment = QueryResult['items'][number]
 
 export type ThumbnailSize = 'small' | 'medium' | 'large'
 
@@ -649,12 +647,9 @@ export class FragmentService {
   }
 
   private readPrefetchedFragment(
-    queryItem: QueryResult['items'][number],
+    queryItem: QueryItemWithPrefetchedFragment,
   ): Fragment | null {
-    const prefetchedFragment = (queryItem as QueryItemWithPrefetchedFragment)
-      .fragment
-
-    return prefetchedFragment ?? null
+    return queryItem.fragment ?? null
   }
 
   private takePrefetchedFragment(cacheKey: string): Fragment | null {

--- a/src/fragmentarium/domain/FragmentDtos.ts
+++ b/src/fragmentarium/domain/FragmentDtos.ts
@@ -58,6 +58,7 @@ export interface TextDto {
   lines: readonly unknown[]
   numberOfLines?: number
   parser_version?: string
+  parserVersion?: string
 }
 
 interface UncuratedReferenceDto {

--- a/src/fragmentarium/infrastructure/FragmentRepository.test.ts
+++ b/src/fragmentarium/infrastructure/FragmentRepository.test.ts
@@ -12,6 +12,9 @@ import { museumNumberToString } from 'fragmentarium/domain/MuseumNumber'
 import { Genre, Genres } from 'fragmentarium/domain/Genres'
 import { mesopotamianDateFactory } from 'test-support/date-fixtures'
 import { archaeologyFactory } from 'test-support/fragment-data-fixtures'
+import { referenceDtoFactory } from 'test-support/bibliography-fixtures'
+import { textLineDto } from 'test-support/lines/text-line'
+import { lineNumberFactory } from 'test-support/linenumber-factory'
 import { FragmentInfo, FragmentInfoDto } from 'fragmentarium/domain/fragment'
 
 const apiClient = {
@@ -506,6 +509,96 @@ describe('FragmentRepository query summary items', () => {
     expect(item.fragment?.archaeology).toBeUndefined()
     expect(item.fragment?.projects).toEqual([])
     expect(item.fragment?.dossiers).toEqual([])
+  })
+})
+
+describe('FragmentRepository raw summary items', () => {
+  it('maps the backend summary envelope into a render-ready query item', async () => {
+    const rawReference = referenceDtoFactory.build({
+      id: 'RAW-REF-1',
+      type: 'DISCUSSION',
+      pages: '1-2',
+      notes: 'raw summary reference',
+      linesCited: ['1.'],
+      document: {
+        id: 'RAW-REF-1',
+        title: 'Raw backend reference',
+        type: 'article-journal',
+        issued: { 'date-parts': [[2024]] },
+        author: [{ family: 'Tester', given: 'T.' }],
+      },
+    })
+    apiClient.fetchJson.mockResolvedValueOnce({
+      matchCountTotal: 1,
+      items: [
+        {
+          museumNumber: { prefix: 'X', number: '42', suffix: 'a' },
+          accession: { prefix: 'A', number: '7', suffix: '' },
+          description: 'Raw backend summary item',
+          script: {
+            period: 'Late Babylonian',
+            periodModifier: 'None',
+            uncertain: false,
+          },
+          date: {
+            year: { value: '10' },
+            month: { value: '5' },
+            day: { value: '12' },
+            isSeleucidEra: true,
+          },
+          genres: [
+            { category: ['ARCHIVE', 'Administrative'], uncertain: false },
+          ],
+          archaeology: {
+            excavationNumber: { prefix: 'BM', number: '123', suffix: '' },
+            site: { name: 'Babylon' },
+          },
+          references: [rawReference],
+          projects: ['CAIC', 'RECC'],
+          dossiers: [{ dossierId: 'D001', isUncertain: false }],
+          matchingLines: [1, 2, 3, 4],
+          matchingLinePreview: {
+            lines: [
+              textLineDto,
+              {
+                ...textLineDto,
+                prefix: '2.',
+                lineNumber: lineNumberFactory.build({ number: 2 }),
+              },
+            ],
+            numberOfLines: 2,
+            // eslint-disable-next-line camelcase
+            parser_version: 'backend',
+          },
+          matchCount: 4,
+          hasPhoto: true,
+          thumbnailPath: '/images/raw-summary.jpg',
+        },
+      ],
+    })
+
+    const result = await fragmentRepository.query({ lemmas: 'raw' })
+    const item = result.items[0]
+
+    expect(item.museumNumber).toEqual(
+      museumNumberToString({ prefix: 'X', number: '42', suffix: 'a' }),
+    )
+    expect(item.thumbnailPath).toEqual('/images/raw-summary.jpg')
+    expect(item.fragment?.hasPhoto).toBe(true)
+    expect(item.fragment?.accession).toEqual(
+      museumNumberToString({ prefix: 'A', number: '7', suffix: '' }),
+    )
+    expect(
+      item.fragment?.projects.map((project) => project.abbreviation),
+    ).toEqual(['CAIC', 'RECC'])
+    expect(item.fragment?.dossiers).toEqual([
+      { dossierId: 'D001', isUncertain: false },
+    ])
+    expect(item.fragment?.archaeology?.excavationNumber).toEqual('BM.123')
+    expect(item.fragment?.archaeology?.site?.name).toEqual('Babylon')
+    expect(item.fragment?.text.lines).toHaveLength(2)
+    expect(item.fragment?.references).toHaveLength(1)
+    expect(item.fragment?.references[0].id).toEqual('RAW-REF-1')
   })
 })
 

--- a/src/fragmentarium/infrastructure/FragmentRepository.test.ts
+++ b/src/fragmentarium/infrastructure/FragmentRepository.test.ts
@@ -477,6 +477,43 @@ describe('FragmentRepository query summary items', () => {
     jest.clearAllMocks()
   })
 
+  it('preserves nullable count and pagination metadata', async () => {
+    apiClient.fetchJson.mockResolvedValueOnce({
+      items: [],
+      matchCountTotal: null,
+      isMatchCountTotalExact: false,
+      hasNextPage: true,
+    })
+
+    await expect(
+      fragmentRepository.query({ transliteration: 'šim' }),
+    ).resolves.toMatchObject({
+      items: [],
+      matchCountTotal: null,
+      isMatchCountTotalExact: false,
+      hasNextPage: true,
+    })
+  })
+
+  it.each(['parser_version', 'parserVersion'] as const)(
+    'accepts matchingLinePreview.%s',
+    async (parserVersionField) => {
+      mockQueryItems([
+        createSummaryItemDto({
+          matchingLinePreview: {
+            lines: [textLineDto],
+            numberOfLines: 1,
+            [parserVersionField]: 'backend',
+          },
+        }),
+      ])
+
+      const result = await fragmentRepository.query({ lemmas: 'kur' })
+
+      expect(result.items[0].fragment?.text.lines).toHaveLength(1)
+    },
+  )
+
   it('maps summary items into prefetched fragments and thumbnail paths', async () => {
     const thumbnailPath = '/images/Test.Fragment.jpg'
     mockQueryItems([createSummaryItemDto({ thumbnailPath })])

--- a/src/fragmentarium/infrastructure/FragmentRepository.test.ts
+++ b/src/fragmentarium/infrastructure/FragmentRepository.test.ts
@@ -424,6 +424,91 @@ const queryTestData: TestData<FragmentRepository>[] = queryTestCases.map(
 describe('Query FragmentRepository', () =>
   testDelegation(fragmentRepository, queryTestData))
 
+describe('FragmentRepository query summary items', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('maps summary items into prefetched fragments and thumbnail paths', async () => {
+    const thumbnailPath = '/images/Test.Fragment.jpg'
+    apiClient.fetchJson.mockResolvedValueOnce({
+      matchCountTotal: 1,
+      items: [
+        {
+          museumNumber: fragmentDto.museumNumber,
+          accession: fragmentDto.accession,
+          description: fragmentDto.description,
+          script: fragmentDto.script,
+          date: fragmentDto.date ?? null,
+          genres: fragmentDto.genres,
+          archaeology: {
+            excavationNumber: fragmentDto.museumNumber,
+            site: { name: 'Sippar' },
+          },
+          references: fragmentDto.references,
+          projects: fragmentDto.projects,
+          dossiers: fragmentDto.dossiers,
+          matchingLines: [1, 2],
+          matchingLinePreview: fragmentDto.text,
+          matchCount: 2,
+          hasPhoto: true,
+          thumbnailPath,
+        },
+      ],
+    })
+
+    const result = await fragmentRepository.query({ transliteration: 'šim' })
+    const item = result.items[0]
+
+    expect(item.museumNumber).toEqual(fragment.number)
+    expect(item.thumbnailPath).toEqual(thumbnailPath)
+    expect(item.fragment?.number).toEqual(fragment.number)
+    expect(item.fragment?.accession).toEqual(fragment.accession)
+    expect(item.fragment?.description).toEqual(fragment.description)
+    expect(item.fragment?.hasPhoto).toBe(true)
+    expect(item.fragment?.archaeology?.excavationNumber).toEqual(
+      fragment.number,
+    )
+    expect(item.fragment?.archaeology?.site?.name).toEqual('Sippar')
+    expect(item.fragment?.text.lines).toHaveLength(fragment.text.lines.length)
+  })
+
+  it('maps summary items when optional fields are omitted', async () => {
+    apiClient.fetchJson.mockResolvedValueOnce({
+      matchCountTotal: 1,
+      items: [
+        {
+          museumNumber: fragmentDto.museumNumber,
+          accession: null,
+          description: fragmentDto.description,
+          script: fragmentDto.script,
+          date: null,
+          genres: [],
+          archaeology: null,
+          references: [],
+          projects: [],
+          dossiers: [],
+          matchingLines: [],
+          matchingLinePreview: fragmentDto.text,
+          matchCount: 0,
+          hasPhoto: false,
+          thumbnailPath: null,
+        },
+      ],
+    })
+
+    const result = await fragmentRepository.query({ number: fragment.number })
+    const item = result.items[0]
+
+    expect(item.thumbnailPath).toBeNull()
+    expect(item.fragment?.accession).toEqual('')
+    expect(item.fragment?.date).toBeUndefined()
+    expect(item.fragment?.archaeology).toBeUndefined()
+    expect(item.fragment?.projects).toEqual([])
+    expect(item.fragment?.dossiers).toEqual([])
+  })
+})
+
 describe('FragmentRepository queryLatest', () => {
   beforeEach(() => {
     jest.clearAllMocks()

--- a/src/fragmentarium/infrastructure/FragmentRepository.test.ts
+++ b/src/fragmentarium/infrastructure/FragmentRepository.test.ts
@@ -15,7 +15,12 @@ import { archaeologyFactory } from 'test-support/fragment-data-fixtures'
 import { referenceDtoFactory } from 'test-support/bibliography-fixtures'
 import { textLineDto } from 'test-support/lines/text-line'
 import { lineNumberFactory } from 'test-support/linenumber-factory'
-import { FragmentInfo, FragmentInfoDto } from 'fragmentarium/domain/fragment'
+import {
+  FragmentInfo,
+  FragmentInfoDto,
+  ScriptDto,
+} from 'fragmentarium/domain/fragment'
+import { PeriodModifiers, Periods } from 'common/utils/period'
 
 const apiClient = {
   fetchJson: jest.fn(),
@@ -427,6 +432,46 @@ const queryTestData: TestData<FragmentRepository>[] = queryTestCases.map(
 describe('Query FragmentRepository', () =>
   testDelegation(fragmentRepository, queryTestData))
 
+const emptyMatchingLinePreview = {
+  lines: [],
+  numberOfLines: 0,
+  // eslint-disable-next-line camelcase
+  parser_version: 'backend',
+}
+
+function createSummaryItemDto(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    museumNumber: fragmentDto.museumNumber,
+    accession: fragmentDto.accession,
+    description: fragmentDto.description,
+    script: fragmentDto.script,
+    date: fragmentDto.date ?? null,
+    genres: fragmentDto.genres,
+    archaeology: {
+      excavationNumber: fragmentDto.museumNumber,
+      site: { name: 'Sippar' },
+    },
+    references: fragmentDto.references,
+    projects: fragmentDto.projects,
+    dossiers: fragmentDto.dossiers,
+    matchingLines: [1, 2],
+    matchingLinePreview: fragmentDto.text,
+    matchCount: 2,
+    hasPhoto: true,
+    thumbnailPath: null,
+    ...overrides,
+  }
+}
+
+function mockQueryItems(items: readonly Record<string, unknown>[]): void {
+  apiClient.fetchJson.mockResolvedValueOnce({
+    matchCountTotal: items.length,
+    items,
+  })
+}
+
 describe('FragmentRepository query summary items', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -434,31 +479,7 @@ describe('FragmentRepository query summary items', () => {
 
   it('maps summary items into prefetched fragments and thumbnail paths', async () => {
     const thumbnailPath = '/images/Test.Fragment.jpg'
-    apiClient.fetchJson.mockResolvedValueOnce({
-      matchCountTotal: 1,
-      items: [
-        {
-          museumNumber: fragmentDto.museumNumber,
-          accession: fragmentDto.accession,
-          description: fragmentDto.description,
-          script: fragmentDto.script,
-          date: fragmentDto.date ?? null,
-          genres: fragmentDto.genres,
-          archaeology: {
-            excavationNumber: fragmentDto.museumNumber,
-            site: { name: 'Sippar' },
-          },
-          references: fragmentDto.references,
-          projects: fragmentDto.projects,
-          dossiers: fragmentDto.dossiers,
-          matchingLines: [1, 2],
-          matchingLinePreview: fragmentDto.text,
-          matchCount: 2,
-          hasPhoto: true,
-          thumbnailPath,
-        },
-      ],
-    })
+    mockQueryItems([createSummaryItemDto({ thumbnailPath })])
 
     const result = await fragmentRepository.query({ transliteration: 'šim' })
     const item = result.items[0]
@@ -476,29 +497,90 @@ describe('FragmentRepository query summary items', () => {
     expect(item.fragment?.text.lines).toHaveLength(fragment.text.lines.length)
   })
 
-  it('maps summary items when optional fields are omitted', async () => {
-    apiClient.fetchJson.mockResolvedValueOnce({
-      matchCountTotal: 1,
-      items: [
-        {
-          museumNumber: fragmentDto.museumNumber,
-          accession: null,
-          description: fragmentDto.description,
-          script: fragmentDto.script,
-          date: null,
-          genres: [],
-          archaeology: null,
-          references: [],
-          projects: [],
-          dossiers: [],
-          matchingLines: [],
-          matchingLinePreview: fragmentDto.text,
-          matchCount: 0,
-          hasPhoto: false,
-          thumbnailPath: null,
-        },
-      ],
+  it('maps summary items with empty matching lines and an empty preview', async () => {
+    mockQueryItems([
+      createSummaryItemDto({
+        matchingLines: [],
+        matchingLinePreview: emptyMatchingLinePreview,
+        matchCount: 0,
+      }),
+    ])
+
+    const result = await fragmentRepository.query({ number: fragment.number })
+    const item = result.items[0]
+
+    expect(item.matchingLines).toEqual([])
+    expect(item.matchCount).toEqual(0)
+    expect(item.thumbnailPath).toBeNull()
+    expect(item.fragment?.number).toEqual(fragment.number)
+    expect(item.fragment?.text.lines).toHaveLength(0)
+  })
+
+  it('keeps old-shape items without summary metadata on the hydration path', async () => {
+    mockQueryItems([
+      {
+        museumNumber: fragmentDto.museumNumber,
+        matchingLines: [],
+        matchCount: 0,
+      },
+    ])
+
+    const result = await fragmentRepository.query({ number: fragment.number })
+    const item = result.items[0]
+
+    expect(item.thumbnailPath).toBeUndefined()
+    expect(item.fragment).toBeUndefined()
+  })
+
+  it('maps summary metadata without matchingLinePreview using an empty preview', async () => {
+    const itemDto = createSummaryItemDto({
+      matchingLines: [],
+      matchCount: 0,
     })
+    delete itemDto.matchingLinePreview
+    delete itemDto.thumbnailPath
+    mockQueryItems([itemDto])
+
+    const result = await fragmentRepository.query({ number: fragment.number })
+    const item = result.items[0]
+
+    expect(item.thumbnailPath).toBeNull()
+    expect(item.fragment?.number).toEqual(fragment.number)
+    expect(item.fragment?.text.lines).toHaveLength(0)
+  })
+
+  it('maps summary metadata with null matchingLinePreview using an empty preview', async () => {
+    mockQueryItems([
+      createSummaryItemDto({
+        matchingLines: [],
+        matchingLinePreview: null,
+        matchCount: 0,
+      }),
+    ])
+
+    const result = await fragmentRepository.query({ number: fragment.number })
+    const item = result.items[0]
+
+    expect(item.fragment?.number).toEqual(fragment.number)
+    expect(item.fragment?.text.lines).toHaveLength(0)
+  })
+
+  it('maps summary items when optional fields are omitted', async () => {
+    mockQueryItems([
+      createSummaryItemDto({
+        accession: null,
+        date: null,
+        genres: [],
+        archaeology: null,
+        references: [],
+        projects: [],
+        dossiers: [],
+        matchingLines: [],
+        matchCount: 0,
+        hasPhoto: false,
+        thumbnailPath: null,
+      }),
+    ])
 
     const result = await fragmentRepository.query({ number: fragment.number })
     const item = result.items[0]
@@ -510,6 +592,29 @@ describe('FragmentRepository query summary items', () => {
     expect(item.fragment?.projects).toEqual([])
     expect(item.fragment?.dossiers).toEqual([])
   })
+
+  it.each<FragmentQuery>([
+    { number: fragment.number },
+    { project: 'CAIC' },
+    { site: 'Sippar' },
+    { genre: 'ARCHIVE' },
+  ])(
+    'maps summary-capable filter rows without matchingLinePreview for %#',
+    async (query) => {
+      const itemDto = createSummaryItemDto({
+        matchingLines: [],
+        matchCount: 0,
+      })
+      delete itemDto.matchingLinePreview
+      mockQueryItems([itemDto])
+
+      const result = await fragmentRepository.query(query)
+      const item = result.items[0]
+
+      expect(item.fragment?.number).toEqual(fragment.number)
+      expect(item.fragment?.text.lines).toHaveLength(0)
+    },
+  )
 })
 
 describe('FragmentRepository raw summary items', () => {
@@ -599,6 +704,112 @@ describe('FragmentRepository raw summary items', () => {
     expect(item.fragment?.text.lines).toHaveLength(2)
     expect(item.fragment?.references).toHaveLength(1)
     expect(item.fragment?.references[0].id).toEqual('RAW-REF-1')
+  })
+})
+
+describe('createScript fallback behavior', () => {
+  it('maps a known period string to its Period object', () => {
+    const dto: ScriptDto = {
+      period: 'Old Babylonian',
+      periodModifier: 'None',
+      uncertain: false,
+    }
+    const result = createScript(dto)
+    expect(result.period).toBe(Periods['Old Babylonian'])
+    expect(result.period.abbreviation).toBe('OB')
+    expect(result.periodModifier).toBe(PeriodModifiers.None)
+  })
+
+  it('falls back to Periods.Uncertain for unrecognized period strings', () => {
+    const dto: ScriptDto = {
+      period: 'ED IIIb' as unknown as string,
+      periodModifier: 'None',
+      uncertain: false,
+    }
+    const result = createScript(dto)
+    expect(result.period).toBe(Periods.Uncertain)
+    expect(result.period.abbreviation).toBe('Unc')
+  })
+
+  it('falls back to Periods.Uncertain when period is not a string', () => {
+    const dto = {
+      period: null,
+      periodModifier: 'None',
+      uncertain: false,
+    } as unknown as ScriptDto
+    const result = createScript(dto)
+    expect(result.period).toBe(Periods.Uncertain)
+    expect(result.period.abbreviation).toBe('Unc')
+  })
+
+  it('falls back to PeriodModifiers.None for unrecognized periodModifier strings', () => {
+    const dto: ScriptDto = {
+      period: 'Old Babylonian',
+      periodModifier: 'VeryLate' as unknown as string,
+      uncertain: false,
+    }
+    const result = createScript(dto)
+    expect(result.periodModifier).toBe(PeriodModifiers.None)
+  })
+
+  it('falls back to PeriodModifiers.None when periodModifier is not a string', () => {
+    const dto = {
+      period: 'Old Babylonian',
+      periodModifier: null,
+      uncertain: false,
+    } as unknown as ScriptDto
+    const result = createScript(dto)
+    expect(result.periodModifier).toBe(PeriodModifiers.None)
+  })
+})
+
+describe('FragmentRepository query summary with unrecognized script', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('produces a render-safe fragment when period is unrecognized', async () => {
+    apiClient.fetchJson.mockResolvedValueOnce({
+      matchCountTotal: 1,
+      items: [
+        createSummaryItemDto({
+          script: {
+            period: 'ED IIIb',
+            periodModifier: 'None',
+            uncertain: false,
+          },
+        } as Record<string, unknown>),
+      ],
+    })
+
+    const result = await fragmentRepository.query({ transliteration: 'kur₂' })
+    const item = result.items[0]
+
+    expect(item.fragment?.script.period.abbreviation).toBeDefined()
+    expect(item.fragment?.script.period.abbreviation).toBe('Unc')
+    expect(item.fragment?.number).toEqual(fragment.number)
+    expect(item.fragment?.script.periodModifier).toBe(PeriodModifiers.None)
+  })
+
+  it('produces a render-safe fragment when period is null', async () => {
+    apiClient.fetchJson.mockResolvedValueOnce({
+      matchCountTotal: 1,
+      items: [
+        createSummaryItemDto({
+          script: {
+            period: null,
+            periodModifier: 'None',
+            uncertain: false,
+          },
+        } as Record<string, unknown>),
+      ],
+    })
+
+    const result = await fragmentRepository.query({ transliteration: 'kur₂' })
+    const item = result.items[0]
+
+    expect(item.fragment?.script.period.abbreviation).toBeDefined()
+    expect(item.fragment?.script.period.abbreviation).toBe('Unc')
   })
 })
 

--- a/src/fragmentarium/infrastructure/FragmentRepository.ts
+++ b/src/fragmentarium/infrastructure/FragmentRepository.ts
@@ -73,10 +73,19 @@ import { ApiEntityAnnotationSpan } from 'fragmentarium/ui/text-annotation/Entity
 import { ProvenanceRecord } from 'fragmentarium/domain/Provenance'
 
 export function createScript(dto: ScriptDto): Script {
+  const period =
+    Periods[dto && typeof dto.period === 'string' ? dto.period : ''] ??
+    Periods.Uncertain
+  const periodModifier =
+    PeriodModifiers[
+      dto && typeof dto.periodModifier === 'string'
+        ? dto.periodModifier
+        : 'None'
+    ] ?? PeriodModifiers.None
   return {
-    ...dto,
-    period: Periods[dto.period],
-    periodModifier: PeriodModifiers[dto.periodModifier],
+    uncertain: dto?.uncertain ?? false,
+    period,
+    periodModifier,
   }
 }
 
@@ -131,7 +140,7 @@ function createFragment(dto: FragmentDto): Fragment {
     uncuratedReferences: dto.uncuratedReferences ?? null,
     cdliImages: dto.cdliImages,
     traditionalReferences: dto.traditionalReferences,
-    genres: Genres.fromJson(dto.genres),
+    genres: Genres.fromJson(dto.genres ?? []),
     script: createScript(dto.script),
     projects: (dto.projects ?? []).map(createResearchProject),
     dossiers: dto.dossiers ?? [],
@@ -178,20 +187,20 @@ type QuerySummaryArchaeologyDto = {
 
 type QuerySummaryItemDto = {
   museumNumber: QueryMuseumNumberDto
-  accession: QueryMuseumNumberDto | null
+  accession?: QueryMuseumNumberDto | null
   description: string
   script: ScriptDto
-  date: MesopotamianDateDto | null
-  genres: FragmentDto['genres']
-  archaeology: QuerySummaryArchaeologyDto
-  references: FragmentDto['references']
-  projects: FragmentDto['projects']
-  dossiers: FragmentDto['dossiers']
+  date?: MesopotamianDateDto | null
+  genres?: FragmentDto['genres']
+  archaeology?: QuerySummaryArchaeologyDto
+  references?: FragmentDto['references']
+  projects?: FragmentDto['projects']
+  dossiers?: FragmentDto['dossiers']
   matchingLines: readonly number[]
-  matchingLinePreview: TextDto
+  matchingLinePreview?: TextDto | null
   matchCount: number
   hasPhoto: boolean
-  thumbnailPath: string | null
+  thumbnailPath?: string | null
 }
 
 type QueryResultItemDto = QueryItemDto | QuerySummaryItemDto
@@ -209,10 +218,12 @@ type QueryResultDto = {
   matchCountTotal: number
 }
 
+const emptyMatchingLinePreview: TextDto = { lines: [], numberOfLines: 0 }
+
 function isQuerySummaryItemDto(
   dto: QueryResultItemDto,
 ): dto is QuerySummaryItemDto {
-  return 'matchingLinePreview' in dto
+  return 'description' in dto && 'script' in dto && 'hasPhoto' in dto
 }
 
 function createQuerySummaryFragment(dto: QuerySummaryItemDto): Fragment {
@@ -236,7 +247,9 @@ function createQuerySummaryFragment(dto: QuerySummaryItemDto): Fragment {
     cdliImages: [],
     folios: [],
     record: [],
-    text: createTransliteration(dto.matchingLinePreview),
+    text: createTransliteration(
+      dto.matchingLinePreview ?? emptyMatchingLinePreview,
+    ),
     notes: { text: '', parts: [] },
     museum: Museums.HYPERURANION,
     references: (dto.references ?? []).map(createReference),
@@ -244,7 +257,7 @@ function createQuerySummaryFragment(dto: QuerySummaryItemDto): Fragment {
     traditionalReferences: [],
     atf: '',
     hasPhoto: dto.hasPhoto,
-    genres: Genres.fromJson(dto.genres),
+    genres: Genres.fromJson(dto.genres ?? []),
     introduction: { text: '', parts: [] },
     script: createScript(dto.script),
     externalNumbers: {},
@@ -280,7 +293,7 @@ function createQueryItem(dto: QueryResultItemDto): QueryItem {
     return {
       ...queryItem,
       fragment: createQuerySummaryFragment(dto),
-      thumbnailPath: dto.thumbnailPath,
+      thumbnailPath: dto.thumbnailPath ?? null,
     }
   }
 

--- a/src/fragmentarium/infrastructure/FragmentRepository.ts
+++ b/src/fragmentarium/infrastructure/FragmentRepository.ts
@@ -47,6 +47,7 @@ import { Joins } from 'fragmentarium/domain/join'
 import { ManuscriptAttestation } from 'corpus/domain/manuscriptAttestation'
 import FragmentDto, {
   MesopotamianDateDto,
+  TextDto,
 } from 'fragmentarium/domain/FragmentDtos'
 import { PeriodModifiers, Periods } from 'common/utils/period'
 import { FragmentQuery } from 'query/FragmentQuery'
@@ -157,18 +158,45 @@ function createFragmentPath(number: string, ...subResources: string[]): string {
   return ['/fragments', encodeURIComponent(number), ...subResources].join('/')
 }
 
+type QueryMuseumNumberDto = {
+  prefix: string
+  number: string
+  suffix: string
+}
+
 type QueryItemDto = {
-  museumNumber: {
-    prefix: string
-    number: string
-    suffix: string
-  }
+  museumNumber: QueryMuseumNumberDto
   matchingLines: readonly number[]
   matchCount: number
   fragment?: FragmentDto
 }
 
-type LatestQueryItemDto = QueryItemDto
+type QuerySummaryArchaeologyDto = {
+  excavationNumber: QueryMuseumNumberDto | null
+  site: { name: string } | null
+} | null
+
+type QuerySummaryItemDto = {
+  museumNumber: QueryMuseumNumberDto
+  accession: QueryMuseumNumberDto | null
+  description: string
+  script: ScriptDto
+  date: MesopotamianDateDto | null
+  genres: FragmentDto['genres']
+  archaeology: QuerySummaryArchaeologyDto
+  references: FragmentDto['references']
+  projects: FragmentDto['projects']
+  dossiers: FragmentDto['dossiers']
+  matchingLines: readonly number[]
+  matchingLinePreview: TextDto
+  matchCount: number
+  hasPhoto: boolean
+  thumbnailPath: string | null
+}
+
+type QueryResultItemDto = QueryItemDto | QuerySummaryItemDto
+
+type LatestQueryItemDto = QueryResultItemDto
 
 type LatestQueryResultDto = {
   items: readonly LatestQueryItemDto[]
@@ -177,18 +205,85 @@ type LatestQueryResultDto = {
 }
 
 type QueryResultDto = {
-  items: readonly QueryItemDto[]
+  items: readonly QueryResultItemDto[]
   matchCountTotal: number
 }
 
-function createQueryItem(
-  dto: QueryItemDto,
-): QueryItem | (QueryItem & { fragment: Fragment }) {
+function isQuerySummaryItemDto(
+  dto: QueryResultItemDto,
+): dto is QuerySummaryItemDto {
+  return 'matchingLinePreview' in dto
+}
+
+function createQuerySummaryFragment(dto: QuerySummaryItemDto): Fragment {
+  return Fragment.create({
+    number: museumNumberToString(dto.museumNumber),
+    accession: dto.accession ? museumNumberToString(dto.accession) : '',
+    publication: '',
+    acquisition: null,
+    description: dto.description,
+    joins: [],
+    measures: {
+      length: null,
+      width: null,
+      thickness: null,
+      lengthNote: null,
+      widthNote: null,
+      thicknessNote: null,
+    },
+    collection: '',
+    legacyScript: '',
+    cdliImages: [],
+    folios: [],
+    record: [],
+    text: createTransliteration(dto.matchingLinePreview),
+    notes: { text: '', parts: [] },
+    museum: Museums.HYPERURANION,
+    references: (dto.references ?? []).map(createReference),
+    uncuratedReferences: null,
+    traditionalReferences: [],
+    atf: '',
+    hasPhoto: dto.hasPhoto,
+    genres: Genres.fromJson(dto.genres),
+    introduction: { text: '', parts: [] },
+    script: createScript(dto.script),
+    externalNumbers: {},
+    projects: (dto.projects ?? []).map(createResearchProject),
+    dossiers: dto.dossiers ?? [],
+    date: dto.date ? MesopotamianDate.fromJson(dto.date) : undefined,
+    datesInText: [],
+    archaeology: dto.archaeology
+      ? {
+          excavationNumber: dto.archaeology.excavationNumber
+            ? museumNumberToString(dto.archaeology.excavationNumber)
+            : undefined,
+          site: dto.archaeology.site
+            ? {
+                name: dto.archaeology.site.name,
+                abbreviation: '',
+                parent: null,
+              }
+            : undefined,
+        }
+      : undefined,
+  })
+}
+
+function createQueryItem(dto: QueryResultItemDto): QueryItem {
   const queryItem = {
     museumNumber: museumNumberToString(dto.museumNumber),
     matchingLines: dto.matchingLines,
     matchCount: dto.matchCount,
   }
+
+  if (isQuerySummaryItemDto(dto)) {
+    return {
+      ...queryItem,
+      fragment: createQuerySummaryFragment(dto),
+      thumbnailPath: dto.thumbnailPath,
+    }
+  }
+
   const prefetchedFragment = dto.fragment && createFragment(dto.fragment)
   return prefetchedFragment
     ? { ...queryItem, fragment: prefetchedFragment }
@@ -215,7 +310,7 @@ function createLatestQueryResult(dto: LatestQueryResultDto): QueryResult {
     items: dto.items.map((itemDto) => {
       const queryItem = createQueryItem(itemDto)
       const prefetchedFragment =
-        (queryItem as QueryItem & { fragment?: Fragment }).fragment ??
+        queryItem.fragment ??
         fragmentsByMuseumNumber.get(queryItem.museumNumber)
 
       return prefetchedFragment

--- a/src/fragmentarium/infrastructure/FragmentRepository.ts
+++ b/src/fragmentarium/infrastructure/FragmentRepository.ts
@@ -227,6 +227,7 @@ function isQuerySummaryItemDto(
 }
 
 function createQuerySummaryFragment(dto: QuerySummaryItemDto): Fragment {
+  // Display-only lightweight fragment: fields absent from the query summary use placeholders.
   return Fragment.create({
     number: museumNumberToString(dto.museumNumber),
     accession: dto.accession ? museumNumberToString(dto.accession) : '',

--- a/src/fragmentarium/infrastructure/FragmentRepository.ts
+++ b/src/fragmentarium/infrastructure/FragmentRepository.ts
@@ -209,16 +209,29 @@ type LatestQueryItemDto = QueryResultItemDto
 
 type LatestQueryResultDto = {
   items: readonly LatestQueryItemDto[]
-  matchCountTotal: number
+  matchCountTotal: number | null
+  isMatchCountTotalExact?: boolean
+  hasNextPage?: boolean | null
   fragments?: readonly FragmentDto[]
 }
 
 type QueryResultDto = {
   items: readonly QueryResultItemDto[]
-  matchCountTotal: number
+  matchCountTotal: number | null
+  isMatchCountTotalExact?: boolean
+  hasNextPage?: boolean | null
 }
 
 const emptyMatchingLinePreview: TextDto = { lines: [], numberOfLines: 0 }
+
+function normalizeMatchingLinePreview(dto?: TextDto | null): TextDto {
+  const { parserVersion, ...preview } = dto ?? emptyMatchingLinePreview
+  return {
+    ...preview,
+    // eslint-disable-next-line camelcase
+    parser_version: preview.parser_version ?? parserVersion,
+  }
+}
 
 function isQuerySummaryItemDto(
   dto: QueryResultItemDto,
@@ -249,7 +262,7 @@ function createQuerySummaryFragment(dto: QuerySummaryItemDto): Fragment {
     folios: [],
     record: [],
     text: createTransliteration(
-      dto.matchingLinePreview ?? emptyMatchingLinePreview,
+      normalizeMatchingLinePreview(dto.matchingLinePreview),
     ),
     notes: { text: '', parts: [] },
     museum: Museums.HYPERURANION,
@@ -307,6 +320,8 @@ function createQueryItem(dto: QueryResultItemDto): QueryItem {
 function createQueryResult(dto: QueryResultDto): QueryResult {
   return {
     matchCountTotal: dto.matchCountTotal,
+    isMatchCountTotalExact: dto.isMatchCountTotalExact,
+    hasNextPage: dto.hasNextPage,
     items: dto.items.map(createQueryItem),
   }
 }
@@ -321,6 +336,8 @@ function createLatestQueryResult(dto: LatestQueryResultDto): QueryResult {
 
   return {
     matchCountTotal: dto.matchCountTotal,
+    isMatchCountTotalExact: dto.isMatchCountTotalExact,
+    hasNextPage: dto.hasNextPage,
     items: dto.items.map((itemDto) => {
       const queryItem = createQueryItem(itemDto)
       const prefetchedFragment =

--- a/src/fragmentarium/ui/front-page/LatestTransliterations.test.tsx
+++ b/src/fragmentarium/ui/front-page/LatestTransliterations.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import Chance from 'chance'
 import { MemoryRouter } from 'react-router-dom'
 import Promise from 'bluebird'
@@ -223,6 +223,105 @@ describe('preview mode', () => {
     expect(fragmentService.findThumbnail).toHaveBeenCalledWith(
       fragmentWithPhoto,
       'small',
+    )
+  })
+
+  test('uses prefetched summary fragments and thumbnail paths without extra fetches', async () => {
+    session = new MemorySession(['read:fragments'])
+    const fragmentWithPhoto = fragmentFactory.build(
+      { hasPhoto: true },
+      { transient: { chance } },
+    )
+    const thumbnailPath = '/images/summary-thumbnail.jpg'
+
+    fragmentService.queryLatest.mockReturnValueOnce(
+      Promise.resolve({
+        items: [
+          {
+            museumNumber: fragmentWithPhoto.number,
+            matchingLines: [1, 2, 3, 4],
+            matchCount: 4,
+            fragment: fragmentWithPhoto,
+            thumbnailPath,
+          },
+        ],
+        matchCountTotal: 4,
+      }),
+    )
+    dossiersService.queryByIds.mockResolvedValue([])
+
+    render(
+      <MemoryRouter>
+        <DictionaryContext.Provider value={wordService}>
+          <SessionContext.Provider value={session}>
+            <LatestTransliterations
+              fragmentService={fragmentService}
+              dossiersService={dossiersService}
+            />
+          </SessionContext.Provider>
+        </DictionaryContext.Provider>
+      </MemoryRouter>,
+    )
+
+    const thumbnail = await screen.findByAltText(
+      `Preview of ${fragmentWithPhoto.number}`,
+    )
+
+    expect(thumbnail).toHaveAttribute('src', thumbnailPath)
+    expect(
+      screen.getByRole('link', {
+        name: `Preview of ${fragmentWithPhoto.number}`,
+      }),
+    ).toHaveAttribute('href', `/library/${fragmentWithPhoto.number}`)
+    expect(fragmentService.find).not.toHaveBeenCalled()
+    expect(fragmentService.findThumbnail).not.toHaveBeenCalled()
+  })
+
+  test('removes broken summary thumbnails after an image error', async () => {
+    session = new MemorySession(['read:fragments'])
+    const fragmentWithPhoto = fragmentFactory.build(
+      { hasPhoto: true },
+      { transient: { chance } },
+    )
+
+    fragmentService.queryLatest.mockReturnValueOnce(
+      Promise.resolve({
+        items: [
+          {
+            museumNumber: fragmentWithPhoto.number,
+            matchingLines: [1, 2, 3, 4],
+            matchCount: 4,
+            fragment: fragmentWithPhoto,
+            thumbnailPath: '/images/broken-thumbnail.jpg',
+          },
+        ],
+        matchCountTotal: 4,
+      }),
+    )
+    dossiersService.queryByIds.mockResolvedValue([])
+
+    render(
+      <MemoryRouter>
+        <DictionaryContext.Provider value={wordService}>
+          <SessionContext.Provider value={session}>
+            <LatestTransliterations
+              fragmentService={fragmentService}
+              dossiersService={dossiersService}
+            />
+          </SessionContext.Provider>
+        </DictionaryContext.Provider>
+      </MemoryRouter>,
+    )
+
+    const thumbnail = await screen.findByAltText(
+      `Preview of ${fragmentWithPhoto.number}`,
+    )
+    fireEvent.error(thumbnail)
+
+    await waitFor(() =>
+      expect(
+        screen.queryByAltText(`Preview of ${fragmentWithPhoto.number}`),
+      ).not.toBeInTheDocument(),
     )
   })
 })

--- a/src/fragmentarium/ui/front-page/LatestTransliterations.test.tsx
+++ b/src/fragmentarium/ui/front-page/LatestTransliterations.test.tsx
@@ -19,6 +19,10 @@ jest.mock('fragmentarium/application/FragmentService')
 jest.mock('dictionary/application/WordService')
 jest.mock('dossiers/application/DossiersService')
 
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
 const chance = new Chance('latest-test')
 
 const numberOfFragments = 2
@@ -268,11 +272,102 @@ describe('preview mode', () => {
     )
 
     expect(thumbnail).toHaveAttribute('src', thumbnailPath)
+    expect(thumbnail).toHaveAttribute('loading', 'lazy')
     expect(
       screen.getByRole('link', {
         name: `Preview of ${fragmentWithPhoto.number}`,
       }),
     ).toHaveAttribute('href', `/library/${fragmentWithPhoto.number}`)
+    expect(fragmentService.find).not.toHaveBeenCalled()
+    expect(fragmentService.findThumbnail).not.toHaveBeenCalled()
+  })
+
+  test('does not show a summary thumbnail when the fragment has no photo', async () => {
+    session = new MemorySession(['read:fragments'])
+    const fragmentWithoutPhoto = fragmentFactory.build(
+      { hasPhoto: false },
+      { transient: { chance } },
+    )
+
+    fragmentService.queryLatest.mockReturnValueOnce(
+      Promise.resolve({
+        items: [
+          {
+            museumNumber: fragmentWithoutPhoto.number,
+            matchingLines: [1, 2, 3, 4],
+            matchCount: 4,
+            fragment: fragmentWithoutPhoto,
+            thumbnailPath: '/images/not-shown.jpg',
+          },
+        ],
+        matchCountTotal: 4,
+      }),
+    )
+    dossiersService.queryByIds.mockResolvedValue([])
+
+    render(
+      <MemoryRouter>
+        <DictionaryContext.Provider value={wordService}>
+          <SessionContext.Provider value={session}>
+            <LatestTransliterations
+              fragmentService={fragmentService}
+              dossiersService={dossiersService}
+            />
+          </SessionContext.Provider>
+        </DictionaryContext.Provider>
+      </MemoryRouter>,
+    )
+
+    await screen.findByText(fragmentWithoutPhoto.number)
+
+    expect(
+      screen.queryByAltText(`Preview of ${fragmentWithoutPhoto.number}`),
+    ).not.toBeInTheDocument()
+    expect(fragmentService.find).not.toHaveBeenCalled()
+    expect(fragmentService.findThumbnail).not.toHaveBeenCalled()
+  })
+
+  test('does not show a summary thumbnail when the thumbnail path is null', async () => {
+    session = new MemorySession(['read:fragments'])
+    const fragmentWithPhoto = fragmentFactory.build(
+      { hasPhoto: true },
+      { transient: { chance } },
+    )
+
+    fragmentService.queryLatest.mockReturnValueOnce(
+      Promise.resolve({
+        items: [
+          {
+            museumNumber: fragmentWithPhoto.number,
+            matchingLines: [1, 2, 3, 4],
+            matchCount: 4,
+            fragment: fragmentWithPhoto,
+            thumbnailPath: null,
+          },
+        ],
+        matchCountTotal: 4,
+      }),
+    )
+    dossiersService.queryByIds.mockResolvedValue([])
+
+    render(
+      <MemoryRouter>
+        <DictionaryContext.Provider value={wordService}>
+          <SessionContext.Provider value={session}>
+            <LatestTransliterations
+              fragmentService={fragmentService}
+              dossiersService={dossiersService}
+            />
+          </SessionContext.Provider>
+        </DictionaryContext.Provider>
+      </MemoryRouter>,
+    )
+
+    await screen.findByText(fragmentWithPhoto.number)
+
+    expect(
+      screen.queryByAltText(`Preview of ${fragmentWithPhoto.number}`),
+    ).not.toBeInTheDocument()
     expect(fragmentService.find).not.toHaveBeenCalled()
     expect(fragmentService.findThumbnail).not.toHaveBeenCalled()
   })

--- a/src/fragmentarium/ui/search/FragmentariumSearch.test.tsx
+++ b/src/fragmentarium/ui/search/FragmentariumSearch.test.tsx
@@ -61,29 +61,34 @@ let fragmentSearchService: jest.Mocked<FragmentSearchService>
 let session: Session
 let container: HTMLElement
 
+const createFragmentariumSearch = (
+  query: Partial<FragmentQuery> = {},
+  activeTab = 'library',
+): React.ReactElement => (
+  <MemoryRouter>
+    <DictionaryContext.Provider value={wordService}>
+      <SessionContext.Provider value={session}>
+        <FragmentariumSearch
+          fragmentSearchService={fragmentSearchService}
+          fragmentService={fragmentService}
+          bibliographyService={bibliographyService}
+          dossiersService={dossiersService}
+          fragmentQuery={query}
+          wordService={wordService}
+          textService={textService}
+          activeTab={activeTab}
+        />
+      </SessionContext.Provider>
+    </DictionaryContext.Provider>
+  </MemoryRouter>
+)
+
 const renderFragmentariumSearch = async (
   waitFor: string,
   query: Partial<FragmentQuery> = {},
   activeTab = 'library',
 ): Promise<void> => {
-  container = render(
-    <MemoryRouter>
-      <DictionaryContext.Provider value={wordService}>
-        <SessionContext.Provider value={session}>
-          <FragmentariumSearch
-            fragmentSearchService={fragmentSearchService}
-            fragmentService={fragmentService}
-            bibliographyService={bibliographyService}
-            dossiersService={dossiersService}
-            fragmentQuery={query}
-            wordService={wordService}
-            textService={textService}
-            activeTab={activeTab}
-          />
-        </SessionContext.Provider>
-      </DictionaryContext.Provider>
-    </MemoryRouter>,
-  ).container
+  container = render(createFragmentariumSearch(query, activeTab)).container
   await screen.findByText(waitFor)
 }
 
@@ -240,46 +245,12 @@ describe('Search', () => {
       Promise.resolve({ items: [], matchCountTotal: 0 }),
     )
 
-    const { rerender } = render(
-      <MemoryRouter>
-        <DictionaryContext.Provider value={wordService}>
-          <SessionContext.Provider value={session}>
-            <FragmentariumSearch
-              fragmentSearchService={fragmentSearchService}
-              fragmentService={fragmentService}
-              bibliographyService={bibliographyService}
-              dossiersService={dossiersService}
-              fragmentQuery={{ transliteration }}
-              wordService={wordService}
-              textService={textService}
-              activeTab="library"
-            />
-          </SessionContext.Provider>
-        </DictionaryContext.Provider>
-      </MemoryRouter>,
-    )
+    const { rerender } = render(createFragmentariumSearch({ transliteration }))
 
     await screen.findByText('Found 2 lines in 2 documents')
     expect(fragmentService.query).toHaveBeenCalledTimes(1)
 
-    rerender(
-      <MemoryRouter>
-        <DictionaryContext.Provider value={wordService}>
-          <SessionContext.Provider value={session}>
-            <FragmentariumSearch
-              fragmentSearchService={fragmentSearchService}
-              fragmentService={fragmentService}
-              bibliographyService={bibliographyService}
-              dossiersService={dossiersService}
-              fragmentQuery={{ transliteration }}
-              wordService={wordService}
-              textService={textService}
-              activeTab="library"
-            />
-          </SessionContext.Provider>
-        </DictionaryContext.Provider>
-      </MemoryRouter>,
-    )
+    rerender(createFragmentariumSearch({ transliteration }))
 
     expect(fragmentService.query).toHaveBeenCalledTimes(1)
     expect(screen.getByText('Found 2 lines in 2 documents')).toBeVisible()
@@ -296,24 +267,7 @@ describe('Search', () => {
     }
     fragmentService.query.mockResolvedValue(differentResult)
 
-    rerender(
-      <MemoryRouter>
-        <DictionaryContext.Provider value={wordService}>
-          <SessionContext.Provider value={session}>
-            <FragmentariumSearch
-              fragmentSearchService={fragmentSearchService}
-              fragmentService={fragmentService}
-              bibliographyService={bibliographyService}
-              dossiersService={dossiersService}
-              fragmentQuery={{ transliteration: 'different text' }}
-              wordService={wordService}
-              textService={textService}
-              activeTab="library"
-            />
-          </SessionContext.Provider>
-        </DictionaryContext.Provider>
-      </MemoryRouter>,
-    )
+    rerender(createFragmentariumSearch({ transliteration: 'different text' }))
 
     await screen.findByText('Found 5 lines in 1 document')
     expect(fragmentService.query).toHaveBeenCalledTimes(2)

--- a/src/fragmentarium/ui/search/FragmentariumSearch.test.tsx
+++ b/src/fragmentarium/ui/search/FragmentariumSearch.test.tsx
@@ -293,6 +293,99 @@ describe('Search', () => {
   })
 })
 
+describe('Search result contract compatibility', () => {
+  const transliteration = 'kur'
+
+  async function renderLibraryResult(result: QueryResult): Promise<void> {
+    fragmentService.query.mockReturnValueOnce(Promise.resolve(result))
+    textService.query.mockReturnValueOnce(
+      Promise.resolve({ items: [], matchCountTotal: 0 }),
+    )
+    wordService.findAll.mockReturnValue(Promise.resolve([]))
+
+    await renderFragmentariumSearch(
+      result.matchCountTotal === null
+        ? `Found ${result.items.length} document${result.items.length === 1 ? '' : 's'}`
+        : `Found about ${result.matchCountTotal} lines in ${result.items.length} document${
+            result.items.length === 1 ? '' : 's'
+          }; more results are available`,
+      { transliteration },
+    )
+  }
+
+  it('renders Fragmentarium results when matchCountTotal is null', async () => {
+    const resultFragment = fragmentFactory.build({
+      hasPhoto: false,
+      dossiers: [],
+    })
+
+    await renderLibraryResult({
+      items: [
+        {
+          museumNumber: resultFragment.number,
+          matchingLines: [1],
+          matchCount: 1,
+          fragment: resultFragment,
+          thumbnailPath: null,
+        },
+      ],
+      matchCountTotal: null,
+    })
+
+    expect(screen.getByText('Found 1 document')).toBeVisible()
+    expect(
+      screen.queryByText('Found 0 lines in 1 document'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('labels inexact totals and incomplete pages', async () => {
+    const resultFragment = fragmentFactory.build({
+      hasPhoto: false,
+      dossiers: [],
+    })
+
+    await renderLibraryResult({
+      items: [
+        {
+          museumNumber: resultFragment.number,
+          matchingLines: [1],
+          matchCount: 1,
+          fragment: resultFragment,
+          thumbnailPath: null,
+        },
+      ],
+      matchCountTotal: 7,
+      isMatchCountTotalExact: false,
+      hasNextPage: true,
+    })
+
+    expect(
+      screen.getByText(
+        'Found about 7 lines in 1 document; more results are available',
+      ),
+    ).toBeVisible()
+  })
+
+  it('renders corpus results when matchCountTotal is null', async () => {
+    fragmentService.query.mockReturnValueOnce(
+      Promise.resolve({ items: [], matchCountTotal: null }),
+    )
+    textService.query.mockReturnValueOnce(
+      Promise.resolve({ items: [], matchCountTotal: null }),
+    )
+    wordService.findAll.mockReturnValue(Promise.resolve([]))
+
+    await renderFragmentariumSearch(
+      'Found 0 chapters',
+      { transliteration },
+      'corpus',
+    )
+
+    expect(screen.getByText('Found 0 chapters')).toBeVisible()
+    expect(screen.queryByText(/Found 0 lines/)).not.toBeInTheDocument()
+  })
+})
+
 describe('Searching fragments by transliteration', () => {
   let result: QueryResult
   let corpusResult: CorpusQueryResult

--- a/src/fragmentarium/ui/search/FragmentariumSearch.test.tsx
+++ b/src/fragmentarium/ui/search/FragmentariumSearch.test.tsx
@@ -1,13 +1,18 @@
 import React from 'react'
 import Chance from 'chance'
+import { produce, castDraft } from 'immer'
 import { MemoryRouter } from 'react-router-dom'
 import { render, screen } from '@testing-library/react'
 import Promise from 'bluebird'
 import FragmentariumSearch from './FragmentariumSearch'
+import Citation from 'bibliography/domain/Citation'
+import BibliographyEntry from 'bibliography/domain/BibliographyEntry'
+import Reference from 'bibliography/domain/Reference'
 import SessionContext from 'auth/SessionContext'
 import FragmentSearchService from 'fragmentarium/application/FragmentSearchService'
 import MemorySession, { Session } from 'auth/Session'
 import { Fragment } from 'fragmentarium/domain/fragment'
+import { fragment, lines } from 'test-support/test-fragment'
 import { fragmentFactory } from 'test-support/fragment-fixtures'
 import WordService from 'dictionary/application/WordService'
 import { DictionaryContext } from 'dictionary/ui/dictionary-context'
@@ -27,6 +32,14 @@ import { LineDetails } from 'corpus/domain/line-details'
 import { lineVariantDisplayFactory } from 'test-support/dictionary-line-fixtures'
 import { queryItemOf } from 'test-support/utils'
 import DossiersService from 'dossiers/application/DossiersService'
+import DossierRecord from 'dossiers/domain/DossierRecord'
+import { Genre, Genres } from 'fragmentarium/domain/Genres'
+import { MesopotamianDate } from 'chronology/domain/Date'
+import { PeriodModifiers, Periods } from 'common/utils/period'
+import { ResearchProjects } from 'research-projects/researchProject'
+import { Text } from 'transliteration/domain/text'
+import { TextLine } from 'transliteration/domain/text-line'
+import { lineNumberFactory } from 'test-support/linenumber-factory'
 
 const chance = new Chance('fragmentarium-search-test')
 
@@ -75,6 +88,7 @@ const renderFragmentariumSearch = async (
 }
 
 beforeEach(async () => {
+  jest.clearAllMocks()
   fragmentSearchService = new (FragmentSearchService as jest.Mock<
     jest.Mocked<FragmentSearchService>
   >)()
@@ -93,6 +107,82 @@ beforeEach(async () => {
   fragmentService.findThumbnail.mockResolvedValue({ blob: null })
   dossiersService.fetchFilteredDossiers.mockReturnValue(Promise.resolve([]))
 })
+
+function buildSummaryBackedFragment(): Fragment {
+  const reference = new Reference(
+    'DISCUSSION',
+    '12-13',
+    '',
+    [],
+    new BibliographyEntry({
+      id: 'RN-SUMMARY-1',
+      title: 'Summary-backed source',
+      type: 'article-journal',
+      issued: {
+        'date-parts': [[2024]],
+      },
+      author: [
+        {
+          given: 'T.',
+          family: 'Tester',
+        },
+        {
+          given: 'A.',
+          family: 'Assistant',
+        },
+      ],
+    }),
+  )
+
+  const previewLine = produce(lines[0], (draft) => {
+    draft.content[1].uniqueLemma = ['test-lemma']
+  })
+  const secondPreviewLine = produce(lines[1], (draft) => {
+    draft.lineNumber = lineNumberFactory.build({ number: 11 })
+    draft.prefix = '11.'
+  })
+
+  return produce(fragment, (draft) => {
+    draft.number = 'X.42'
+    draft.accession = 'A.7'
+    draft.script = {
+      period: Periods['Neo-Assyrian'],
+      periodModifier: PeriodModifiers.None,
+      uncertain: false,
+    }
+    draft.genres = castDraft(
+      new Genres([
+        new Genre(['ARCHIVE', 'Administrative'], false),
+        new Genre(['CANONICAL', 'Divination'], true),
+      ]),
+    )
+    draft.projects = [ResearchProjects.CAIC, ResearchProjects.RECC]
+    draft.references = castDraft([reference])
+    draft.dossiers = [{ dossierId: 'D001', isUncertain: false }]
+    draft.date = MesopotamianDate.fromJson({
+      year: { value: '10' },
+      month: { value: '5' },
+      day: { value: '12' },
+      isSeleucidEra: true,
+    })
+    draft.archaeology = {
+      excavationNumber: 'BM.123',
+      site: {
+        name: 'Babylon',
+        abbreviation: 'Bab',
+        parent: null,
+      },
+      isRegularExcavation: true,
+      isFindspotUncertain: false,
+    }
+    draft.text = castDraft(
+      new Text({
+        lines: [new TextLine(previewLine), new TextLine(secondPreviewLine)],
+      }),
+    )
+    draft.hasPhoto = false
+  })
+}
 
 describe('Search', () => {
   let fragments: Fragment[]
@@ -239,5 +329,72 @@ describe('Searching fragments by transliteration', () => {
 
     await userEvent.click(screen.getByRole('tab', { name: 'Library' }))
     expect(global.window.location.hash).toEqual('#library')
+  })
+})
+
+describe('Searching fragments from summary-backed results', () => {
+  it('renders the prefetched summary row without hydrating the fragment', async () => {
+    const summaryFragment = buildSummaryBackedFragment()
+    const citation = Citation.for(summaryFragment.references[0]).getMarkdown()
+
+    fragmentService.query.mockReturnValueOnce(
+      Promise.resolve({
+        items: [
+          {
+            museumNumber: summaryFragment.number,
+            matchingLines: [1, 2, 3, 4, 5, 6, 7],
+            matchCount: 7,
+            fragment: summaryFragment,
+          },
+        ],
+        matchCountTotal: 7,
+      }),
+    )
+    wordService.findAll.mockReturnValue(Promise.resolve([]))
+    textService.query.mockReturnValueOnce(
+      Promise.resolve({ items: [], matchCountTotal: 0 }),
+    )
+    dossiersService.queryByIds.mockResolvedValue([
+      new DossierRecord({
+        _id: 'D001',
+        description: 'Summary dossier',
+      }),
+    ])
+
+    await renderFragmentariumSearch(summaryFragment.number, {
+      lemmas: 'test-lemma',
+    })
+
+    expect(fragmentService.find).not.toHaveBeenCalled()
+    expect(screen.getByText('Found 7 lines in 1 document')).toBeVisible()
+    expect(
+      screen.getByRole('heading', {
+        name: `${summaryFragment.number} (${summaryFragment.script.period.abbreviation})`,
+      }),
+    ).toBeVisible()
+    expect(
+      screen.getByText(`Accession no.: ${summaryFragment.accession}`),
+    ).toBeVisible()
+    expect(
+      screen.getByText(
+        `Excavation no.: ${summaryFragment.archaeology?.excavationNumber}`,
+      ),
+    ).toBeVisible()
+    expect(
+      screen.getByText(
+        `Provenance: ${summaryFragment.archaeology?.site?.name}`,
+      ),
+    ).toBeVisible()
+    expect(screen.getByText('ARCHIVE ➝ Administrative')).toBeVisible()
+    expect(screen.getByText('CANONICAL ➝ Divination (?)')).toBeVisible()
+    expect(screen.getByRole('time')).toHaveTextContent(
+      summaryFragment.date!.toString().split(' (')[0],
+    )
+    expect(screen.getByRole('time')).toHaveTextContent('30 August 302 BCE PJC')
+    expect(screen.getByText(citation)).toBeVisible()
+    expect(screen.getByAltText(ResearchProjects.CAIC.name)).toBeVisible()
+    expect(screen.getByAltText(ResearchProjects.RECC.name)).toBeVisible()
+    expect(screen.getByRole('button', { name: 'D001' })).toBeVisible()
+    expect(screen.getByText('And 2 more')).toBeVisible()
   })
 })

--- a/src/fragmentarium/ui/search/FragmentariumSearch.test.tsx
+++ b/src/fragmentarium/ui/search/FragmentariumSearch.test.tsx
@@ -221,6 +221,104 @@ describe('Search', () => {
     })
   })
 
+  it('Does not refetch on equivalent query with new object reference', async () => {
+    const transliteration = 'LI₂₃ ši₂-ṣa-pel₃-ṭa₃'
+    const fragments = fragmentFactory.buildList(
+      2,
+      {},
+      { transient: { chance } },
+    )
+    const result: QueryResult = {
+      items: fragments.map(queryItemOf),
+      matchCountTotal: 2,
+    }
+
+    fragmentService.query.mockResolvedValue(result)
+    fragmentService.find.mockResolvedValue(fragments[0])
+    wordService.findAll.mockReturnValue(Promise.resolve([]))
+    textService.query.mockReturnValue(
+      Promise.resolve({ items: [], matchCountTotal: 0 }),
+    )
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <DictionaryContext.Provider value={wordService}>
+          <SessionContext.Provider value={session}>
+            <FragmentariumSearch
+              fragmentSearchService={fragmentSearchService}
+              fragmentService={fragmentService}
+              bibliographyService={bibliographyService}
+              dossiersService={dossiersService}
+              fragmentQuery={{ transliteration }}
+              wordService={wordService}
+              textService={textService}
+              activeTab="library"
+            />
+          </SessionContext.Provider>
+        </DictionaryContext.Provider>
+      </MemoryRouter>,
+    )
+
+    await screen.findByText('Found 2 lines in 2 documents')
+    expect(fragmentService.query).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <MemoryRouter>
+        <DictionaryContext.Provider value={wordService}>
+          <SessionContext.Provider value={session}>
+            <FragmentariumSearch
+              fragmentSearchService={fragmentSearchService}
+              fragmentService={fragmentService}
+              bibliographyService={bibliographyService}
+              dossiersService={dossiersService}
+              fragmentQuery={{ transliteration }}
+              wordService={wordService}
+              textService={textService}
+              activeTab="library"
+            />
+          </SessionContext.Provider>
+        </DictionaryContext.Provider>
+      </MemoryRouter>,
+    )
+
+    expect(fragmentService.query).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('Found 2 lines in 2 documents')).toBeVisible()
+
+    const differentResult: QueryResult = {
+      items: [
+        {
+          museumNumber: fragments[0].number,
+          matchingLines: [],
+          matchCount: 0,
+        },
+      ],
+      matchCountTotal: 5,
+    }
+    fragmentService.query.mockResolvedValue(differentResult)
+
+    rerender(
+      <MemoryRouter>
+        <DictionaryContext.Provider value={wordService}>
+          <SessionContext.Provider value={session}>
+            <FragmentariumSearch
+              fragmentSearchService={fragmentSearchService}
+              fragmentService={fragmentService}
+              bibliographyService={bibliographyService}
+              dossiersService={dossiersService}
+              fragmentQuery={{ transliteration: 'different text' }}
+              wordService={wordService}
+              textService={textService}
+              activeTab="library"
+            />
+          </SessionContext.Provider>
+        </DictionaryContext.Provider>
+      </MemoryRouter>,
+    )
+
+    await screen.findByText('Found 5 lines in 1 document')
+    expect(fragmentService.query).toHaveBeenCalledTimes(2)
+  })
+
   it('Shows suggestion when entering wrong number format', async () => {
     fragmentService.query.mockReturnValueOnce(
       Promise.resolve({
@@ -366,6 +464,7 @@ describe('Searching fragments from summary-backed results', () => {
     })
 
     expect(fragmentService.find).not.toHaveBeenCalled()
+    expect(screen.queryByLabelText('Spinner')).not.toBeInTheDocument()
     expect(screen.getByText('Found 7 lines in 1 document')).toBeVisible()
     expect(
       screen.getByRole('heading', {

--- a/src/fragmentarium/ui/search/FragmentariumSearchResult.tsx
+++ b/src/fragmentarium/ui/search/FragmentariumSearchResult.tsx
@@ -117,6 +117,6 @@ export const SearchResult = withData<
   },
   ({ fragmentService, fragmentQuery }) => fragmentService.query(fragmentQuery),
   {
-    watch: ({ fragmentQuery }) => [fragmentQuery],
+    watch: ({ fragmentQuery }) => [stringify(fragmentQuery)],
   },
 )

--- a/src/fragmentarium/ui/search/FragmentariumSearchResult.tsx
+++ b/src/fragmentarium/ui/search/FragmentariumSearchResult.tsx
@@ -68,9 +68,12 @@ export const SearchResult = withData<
   ({ data, fragmentService, dossiersService, fragmentQuery }): JSX.Element => {
     const fragmentCount = data.items.length
     const isLineQuery = fragmentQuery.lemmas || fragmentQuery.transliteration
-    const lineCountInfo = `${data.matchCountTotal.toLocaleString()} line${
-      data.matchCountTotal === 1 ? '' : 's'
-    } in `
+    const hasLineCount = typeof data.matchCountTotal === 'number'
+    const lineCountInfo = hasLineCount
+      ? `${data.isMatchCountTotalExact === false ? 'about ' : ''}${data.matchCountTotal.toLocaleString()} line${
+          data.matchCountTotal === 1 ? '' : 's'
+        } in `
+      : ''
     const showNumberSuggestion =
       fragmentCount === 0 && fragmentQuery.number?.match(/^[^.]+\s+[^.]+$/)
     const fixedNumber = fragmentQuery.number?.split(/\s+/).join('.')
@@ -82,6 +85,7 @@ export const SearchResult = withData<
             {`${fragmentCount.toLocaleString()} document${
               fragmentCount === 1 ? '' : 's'
             }`}
+            {data.hasNextPage === true && '; more results are available'}
             {showNumberSuggestion && (
               <>
                 {'. Did you mean'}

--- a/src/fragmentarium/ui/search/FragmentariumSearchResultComponents.test.tsx
+++ b/src/fragmentarium/ui/search/FragmentariumSearchResultComponents.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import Bluebird from 'bluebird'
+import { MemoryRouter } from 'react-router-dom'
+import { render, screen } from '@testing-library/react'
+import { QueryItem } from 'query/QueryResult'
+import FragmentService from 'fragmentarium/application/FragmentService'
+import DossiersService from 'dossiers/application/DossiersService'
+import { DictionaryContext } from 'dictionary/ui/dictionary-context'
+import WordService from 'dictionary/application/WordService'
+import { fragmentFactory } from 'test-support/fragment-fixtures'
+import { Text } from 'transliteration/domain/text'
+import { FragmentLines } from './FragmentariumSearchResultComponents'
+
+jest.mock('fragmentarium/application/FragmentService')
+jest.mock('dossiers/application/DossiersService')
+jest.mock('dictionary/application/WordService')
+
+const fragmentService = new (FragmentService as jest.Mock<
+  jest.Mocked<FragmentService>
+>)()
+const dossiersService = new (DossiersService as jest.Mock<
+  jest.Mocked<DossiersService>
+>)()
+const wordService = new (WordService as jest.Mock<jest.Mocked<WordService>>)()
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  dossiersService.queryByIds.mockResolvedValue([])
+})
+
+function renderFragmentLines(queryItem: QueryItem) {
+  return render(
+    <MemoryRouter>
+      <DictionaryContext.Provider value={wordService}>
+        <FragmentLines
+          fragmentService={fragmentService}
+          dossiersService={dossiersService}
+          queryItem={queryItem}
+          linesToShow={3}
+        />
+      </DictionaryContext.Provider>
+    </MemoryRouter>,
+  )
+}
+
+describe('FragmentLines', () => {
+  it('renders summary-backed rows without hydrating them', async () => {
+    const fragment = fragmentFactory.build({
+      hasPhoto: false,
+      dossiers: [],
+    })
+
+    renderFragmentLines({
+      museumNumber: fragment.number,
+      matchingLines: [1, 2, 3],
+      matchCount: 3,
+      fragment,
+      thumbnailPath: null,
+    })
+
+    expect(fragmentService.find).not.toHaveBeenCalled()
+    expect(screen.queryByLabelText('Spinner')).not.toBeInTheDocument()
+    expect(screen.getByText(fragment.number)).toBeInTheDocument()
+  })
+
+  it('renders summary-backed rows with empty previews without hydrating them', async () => {
+    const fragment = fragmentFactory.build({
+      hasPhoto: false,
+      dossiers: [],
+      text: new Text({ lines: [] }),
+    })
+
+    renderFragmentLines({
+      museumNumber: fragment.number,
+      matchingLines: [],
+      matchCount: 0,
+      fragment,
+      thumbnailPath: null,
+    })
+
+    expect(fragmentService.find).not.toHaveBeenCalled()
+    expect(screen.queryByLabelText('Spinner')).not.toBeInTheDocument()
+    expect(screen.getByText(fragment.number)).toBeInTheDocument()
+  })
+
+  it('shows the hydration spinner when the query item is not render-ready', async () => {
+    fragmentService.find.mockReturnValueOnce(
+      new Bluebird(() => undefined) as unknown as Bluebird<never>,
+    )
+
+    renderFragmentLines({
+      museumNumber: 'X.1',
+      matchingLines: [1, 2, 3],
+      matchCount: 3,
+    })
+
+    expect(fragmentService.find).toHaveBeenCalledWith('X.1', [1, 2, 3], false)
+    expect(await screen.findByLabelText('Spinner')).toBeInTheDocument()
+    expect(screen.queryByText('X.1')).not.toBeInTheDocument()
+  })
+})

--- a/src/fragmentarium/ui/search/FragmentariumSearchResultComponents.test.tsx
+++ b/src/fragmentarium/ui/search/FragmentariumSearchResultComponents.test.tsx
@@ -83,6 +83,28 @@ describe('FragmentLines', () => {
     expect(screen.getByText(fragment.number)).toBeInTheDocument()
   })
 
+  it('uses summary thumbnail paths without fetching thumbnail blobs', async () => {
+    const fragment = fragmentFactory.build({
+      hasPhoto: true,
+      dossiers: [],
+    })
+    const thumbnailPath = '/images/summary-thumbnail.jpg'
+
+    renderFragmentLines({
+      museumNumber: fragment.number,
+      matchingLines: [1, 2, 3],
+      matchCount: 3,
+      fragment,
+      thumbnailPath,
+    })
+
+    expect(
+      await screen.findByAltText(`Preview of ${fragment.number}`),
+    ).toHaveAttribute('src', thumbnailPath)
+    expect(fragmentService.find).not.toHaveBeenCalled()
+    expect(fragmentService.findThumbnail).not.toHaveBeenCalled()
+  })
+
   it('shows the hydration spinner when the query item is not render-ready', async () => {
     fragmentService.find.mockReturnValueOnce(
       new Bluebird(() => undefined) as unknown as Bluebird<never>,

--- a/src/fragmentarium/ui/search/FragmentariumSearchResultComponents.tsx
+++ b/src/fragmentarium/ui/search/FragmentariumSearchResultComponents.tsx
@@ -5,7 +5,7 @@ import FragmentService, {
 } from 'fragmentarium/application/FragmentService'
 import withData from 'http/withData'
 import { QueryItem } from 'query/QueryResult'
-import { Col, Container, Row } from 'react-bootstrap'
+import { Col, Container, Image, Row } from 'react-bootstrap'
 import { Fragment } from 'fragmentarium/domain/fragment'
 import { RenderFragmentLines } from 'dictionary/ui/search/FragmentLemmaLines'
 import FragmentLink, { createFragmentUrl } from '../FragmentLink'
@@ -56,6 +56,33 @@ const FragmentThumbnail = withData<
     fragmentService.findThumbnail(fragment, 'small'),
 )
 
+function SummaryThumbnail({
+  fragmentNumber,
+  thumbnailPath,
+}: {
+  fragmentNumber: string
+  thumbnailPath: string | null
+}): JSX.Element {
+  const [isBroken, setIsBroken] = React.useState(false)
+
+  if (!thumbnailPath || isBroken) {
+    return <></>
+  }
+
+  return (
+    <a href={createFragmentUrl(fragmentNumber)}>
+      <Image
+        src={thumbnailPath}
+        alt={`Preview of ${fragmentNumber}`}
+        fluid
+        loading="lazy"
+        decoding="async"
+        onError={() => setIsBroken(true)}
+      />
+    </a>
+  )
+}
+
 function TransliterationRecord({
   record,
   className,
@@ -78,113 +105,137 @@ function ResponsiveCol({ ...props }): JSX.Element {
   return <Col xs={12} sm={4} {...props}></Col>
 }
 
-export const FragmentLines = withData<
-  {
-    queryLemmas?: readonly string[]
-    queryItem: QueryItem
-    linesToShow: number
-    includeLatestRecord?: boolean
-    fragmentService: FragmentService
-    dossiersService: DossiersService
-  },
+type FragmentLinesProps = {
+  queryLemmas?: readonly string[]
+  queryItem: QueryItem
+  linesToShow: number
+  includeLatestRecord?: boolean
+  fragmentService: FragmentService
+  dossiersService: DossiersService
+  active?: number
+}
+
+function hasRenderReadyFragment(
+  queryItem: QueryItem,
+): queryItem is QueryItem & { fragment: Fragment } {
+  return Boolean(queryItem.fragment)
+}
+
+function FragmentLinesContent({
+  fragment,
+  queryItem,
+  queryLemmas,
+  linesToShow,
+  includeLatestRecord,
+  fragmentService,
+  dossiersService,
+}: FragmentLinesProps & { fragment: Fragment }): JSX.Element {
+  const { containerRef: thumbnailContainerRef, isNearViewport } =
+    useNearViewport()
+  const script = fragment.script.period.abbreviation
+    ? ` (${fragment.script.period.abbreviation})`
+    : ''
+  const usesSummaryThumbnail = 'thumbnailPath' in queryItem
+
+  return (
+    <Container>
+      <Row className={'fragment-result__header'}>
+        <ResponsiveCol>
+          <h4 className={'fragment-result__fragment-number'}>
+            <FragmentLink number={fragment.number}>
+              {fragment.number}
+            </FragmentLink>
+            {script}
+          </h4>
+          <div className="fragment-result__archaeology-info">
+            <small>
+              <p>
+                {fragment.accession && 'Accession no.: '}
+                {fragment.accession}
+              </p>
+              <p>
+                {fragment.archaeology?.excavationNumber && 'Excavation no.: '}
+                {fragment.archaeology?.excavationNumber}
+              </p>
+              <p>
+                {fragment.archaeology?.site?.name && 'Provenance: '}
+                {fragment.archaeology?.site?.name}
+              </p>
+              <FragmentDossierRecordsDisplay
+                dossiersService={dossiersService}
+                fragment={fragment}
+              />
+            </small>
+          </div>
+          <ProjectList projects={fragment.projects} />
+        </ResponsiveCol>
+        <ResponsiveCol className={'text-secondary fragment-result__genre'}>
+          <GenresDisplay genres={fragment.genres} />
+        </ResponsiveCol>
+        <ResponsiveCol className={'fragment-result__record'}>
+          {includeLatestRecord && (
+            <TransliterationRecord record={fragment.uniqueRecord} />
+          )}
+        </ResponsiveCol>
+      </Row>
+      {fragment?.date && (
+        <Row>
+          <ResponsiveCol>
+            <DateDisplay date={fragment.date} />
+          </ResponsiveCol>
+        </Row>
+      )}
+      <Row>
+        <ResponsiveCol className={'text-secondary'}>
+          <small>
+            <ReferenceList references={fragment.references} />
+          </small>
+        </ResponsiveCol>
+        <ResponsiveCol className={'mt-4 mb-4 mt-sm-0 mb-sm-0'}>
+          <RenderFragmentLines
+            fragment={fragment}
+            linesToShow={linesToShow}
+            totalLines={queryItem.matchingLines.length}
+            lemmaIds={queryLemmas}
+          />
+        </ResponsiveCol>
+        <ResponsiveCol className={'fragment-result__preview'}>
+          <ErrorBoundary>
+            <div ref={thumbnailContainerRef}>
+              {fragment.hasPhoto && isNearViewport && (
+                <>
+                  {usesSummaryThumbnail ? (
+                    <SummaryThumbnail
+                      fragmentNumber={fragment.number}
+                      thumbnailPath={queryItem.thumbnailPath ?? null}
+                    />
+                  ) : (
+                    <FragmentThumbnail
+                      fragmentService={fragmentService}
+                      fragment={fragment}
+                    />
+                  )}
+                </>
+              )}
+            </div>
+          </ErrorBoundary>
+        </ResponsiveCol>
+      </Row>
+      <hr />
+    </Container>
+  )
+}
+
+const HydratedFragmentLines = withData<
+  Omit<FragmentLinesProps, 'active'>,
   {
     active?: number
   },
   Fragment
 >(
-  ({
-    data: fragment,
-    queryLemmas,
-    queryItem,
-    linesToShow,
-    includeLatestRecord,
-    fragmentService,
-    dossiersService,
-  }): JSX.Element => {
-    const { containerRef: thumbnailContainerRef, isNearViewport } =
-      useNearViewport()
-    const script = fragment.script.period.abbreviation
-      ? ` (${fragment.script.period.abbreviation})`
-      : ''
-    return (
-      <Container>
-        <Row className={'fragment-result__header'}>
-          <ResponsiveCol>
-            <h4 className={'fragment-result__fragment-number'}>
-              <FragmentLink number={fragment.number}>
-                {fragment.number}
-              </FragmentLink>
-              {script}
-            </h4>
-            <div className="fragment-result__archaeology-info">
-              <small>
-                <p>
-                  {fragment.accession && 'Accession no.: '}
-                  {fragment.accession}
-                </p>
-                <p>
-                  {fragment.archaeology?.excavationNumber && 'Excavation no.: '}
-                  {fragment.archaeology?.excavationNumber}
-                </p>
-                <p>
-                  {fragment.archaeology?.site?.name && 'Provenance: '}
-                  {fragment.archaeology?.site?.name}
-                </p>
-                <FragmentDossierRecordsDisplay
-                  dossiersService={dossiersService}
-                  fragment={fragment}
-                />
-              </small>
-            </div>
-            <ProjectList projects={fragment.projects} />
-          </ResponsiveCol>
-          <ResponsiveCol className={'text-secondary fragment-result__genre'}>
-            <GenresDisplay genres={fragment.genres} />
-          </ResponsiveCol>
-          <ResponsiveCol className={'fragment-result__record'}>
-            {includeLatestRecord && (
-              <TransliterationRecord record={fragment.uniqueRecord} />
-            )}
-          </ResponsiveCol>
-        </Row>
-        {fragment?.date && (
-          <Row>
-            <ResponsiveCol>
-              <DateDisplay date={fragment.date} />
-            </ResponsiveCol>
-          </Row>
-        )}
-        <Row>
-          <ResponsiveCol className={'text-secondary'}>
-            <small>
-              <ReferenceList references={fragment.references} />
-            </small>
-          </ResponsiveCol>
-          <ResponsiveCol className={'mt-4 mb-4 mt-sm-0 mb-sm-0'}>
-            <RenderFragmentLines
-              fragment={fragment}
-              linesToShow={linesToShow}
-              totalLines={queryItem.matchingLines.length}
-              lemmaIds={queryLemmas}
-            />
-          </ResponsiveCol>
-          <ResponsiveCol className={'fragment-result__preview'}>
-            <ErrorBoundary>
-              <div ref={thumbnailContainerRef}>
-                {fragment.hasPhoto && isNearViewport && (
-                  <FragmentThumbnail
-                    fragmentService={fragmentService}
-                    fragment={fragment}
-                  />
-                )}
-              </div>
-            </ErrorBoundary>
-          </ResponsiveCol>
-        </Row>
-        <hr />
-      </Container>
-    )
-  },
+  ({ data: fragment, ...props }): JSX.Element => (
+    <FragmentLinesContent fragment={fragment} {...props} />
+  ),
   ({ fragmentService, queryItem, linesToShow }) => {
     const excludeLines = _.isEmpty(queryItem.matchingLines)
     return fragmentService.find(
@@ -197,3 +248,11 @@ export const FragmentLines = withData<
     watch: ({ active }) => [active],
   },
 )
+
+export function FragmentLines(props: FragmentLinesProps): JSX.Element {
+  return hasRenderReadyFragment(props.queryItem) ? (
+    <FragmentLinesContent fragment={props.queryItem.fragment} {...props} />
+  ) : (
+    <HydratedFragmentLines {...props} />
+  )
+}

--- a/src/fragmentarium/ui/search/__snapshots__/FragmentariumSearch.test.tsx.snap
+++ b/src/fragmentarium/ui/search/__snapshots__/FragmentariumSearch.test.tsx.snap
@@ -135,7 +135,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                               >
                                 <span
                                   class="css-1f43avz-a11yText-A11yText"
-                                  id="react-select-20-live-region"
+                                  id="react-select-29-live-region"
                                 />
                                 <span
                                   aria-atomic="false"
@@ -152,7 +152,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                   >
                                     <div
                                       class="search-form-select__placeholder css-1jqq78o-placeholder"
-                                      id="react-select-20-placeholder"
+                                      id="react-select-29-placeholder"
                                     >
                                       Name Year Title
                                     </div>
@@ -163,7 +163,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                       <input
                                         aria-activedescendant=""
                                         aria-autocomplete="list"
-                                        aria-describedby="react-select-20-placeholder"
+                                        aria-describedby="react-select-29-placeholder"
                                         aria-expanded="false"
                                         aria-haspopup="true"
                                         aria-label="Select bibliography reference"
@@ -171,7 +171,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                         autocomplete="off"
                                         autocorrect="off"
                                         class="search-form-select__input"
-                                        id="react-select-20-input"
+                                        id="react-select-29-input"
                                         role="combobox"
                                         spellcheck="false"
                                         style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -250,7 +250,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                               >
                                 <span
                                   class="css-1f43avz-a11yText-A11yText"
-                                  id="react-select-23-live-region"
+                                  id="react-select-32-live-region"
                                 />
                                 <span
                                   aria-atomic="false"
@@ -267,7 +267,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                   >
                                     <div
                                       class="search-form-select__placeholder css-1jqq78o-placeholder"
-                                      id="react-select-23-placeholder"
+                                      id="react-select-32-placeholder"
                                     >
                                       Lemmata
                                     </div>
@@ -278,7 +278,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                       <input
                                         aria-activedescendant=""
                                         aria-autocomplete="list"
-                                        aria-describedby="react-select-23-placeholder"
+                                        aria-describedby="react-select-32-placeholder"
                                         aria-expanded="false"
                                         aria-haspopup="true"
                                         aria-label="Select lemmata"
@@ -286,7 +286,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                         autocomplete="off"
                                         autocorrect="off"
                                         class="search-form-select__input"
-                                        id="react-select-23-input"
+                                        id="react-select-32-input"
                                         role="combobox"
                                         spellcheck="false"
                                         style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -331,7 +331,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                               >
                                 <span
                                   class="css-1f43avz-a11yText-A11yText"
-                                  id="react-select-24-live-region"
+                                  id="react-select-33-live-region"
                                 />
                                 <span
                                   aria-atomic="false"
@@ -365,7 +365,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                         autocomplete="off"
                                         autocorrect="off"
                                         class="search-form-select__input"
-                                        id="react-select-24-input"
+                                        id="react-select-33-input"
                                         role="combobox"
                                         spellcheck="false"
                                         style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -454,7 +454,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                           >
                             <span
                               class="css-1f43avz-a11yText-A11yText"
-                              id="react-select-25-live-region"
+                              id="react-select-34-live-region"
                             />
                             <span
                               aria-atomic="false"
@@ -471,7 +471,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                               >
                                 <div
                                   class="genre-selector__placeholder css-1jqq78o-placeholder"
-                                  id="react-select-25-placeholder"
+                                  id="react-select-34-placeholder"
                                 >
                                   Genre
                                 </div>
@@ -482,7 +482,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                   <input
                                     aria-activedescendant=""
                                     aria-autocomplete="list"
-                                    aria-describedby="react-select-25-placeholder"
+                                    aria-describedby="react-select-34-placeholder"
                                     aria-expanded="false"
                                     aria-haspopup="true"
                                     aria-label="select-genre"
@@ -490,7 +490,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                     autocomplete="off"
                                     autocorrect="off"
                                     class="genre-selector__input"
-                                    id="react-select-25-input"
+                                    id="react-select-34-input"
                                     role="combobox"
                                     spellcheck="false"
                                     style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -548,7 +548,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                           >
                             <span
                               class="css-1f43avz-a11yText-A11yText"
-                              id="react-select-21-live-region"
+                              id="react-select-30-live-region"
                             />
                             <span
                               aria-atomic="false"
@@ -565,7 +565,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                               >
                                 <div
                                   class="museum-selector__placeholder css-1jqq78o-placeholder"
-                                  id="react-select-21-placeholder"
+                                  id="react-select-30-placeholder"
                                 >
                                   Museum
                                 </div>
@@ -576,7 +576,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                   <input
                                     aria-activedescendant=""
                                     aria-autocomplete="list"
-                                    aria-describedby="react-select-21-placeholder"
+                                    aria-describedby="react-select-30-placeholder"
                                     aria-expanded="false"
                                     aria-haspopup="true"
                                     aria-label="select-museum"
@@ -584,7 +584,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                     autocomplete="off"
                                     autocorrect="off"
                                     class="museum-selector__input"
-                                    id="react-select-21-input"
+                                    id="react-select-30-input"
                                     role="combobox"
                                     spellcheck="false"
                                     style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -648,7 +648,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                               >
                                 <span
                                   class="css-1f43avz-a11yText-A11yText"
-                                  id="react-select-26-live-region"
+                                  id="react-select-35-live-region"
                                 />
                                 <span
                                   aria-atomic="false"
@@ -665,7 +665,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                   >
                                     <div
                                       class="search-form-select__placeholder css-1jqq78o-placeholder"
-                                      id="react-select-26-placeholder"
+                                      id="react-select-35-placeholder"
                                     >
                                       Period
                                     </div>
@@ -676,7 +676,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                       <input
                                         aria-activedescendant=""
                                         aria-autocomplete="list"
-                                        aria-describedby="react-select-26-placeholder"
+                                        aria-describedby="react-select-35-placeholder"
                                         aria-expanded="false"
                                         aria-haspopup="true"
                                         aria-label="select-period"
@@ -684,7 +684,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                         autocomplete="off"
                                         autocorrect="off"
                                         class="search-form-select__input"
-                                        id="react-select-26-input"
+                                        id="react-select-35-input"
                                         role="combobox"
                                         spellcheck="false"
                                         style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -729,7 +729,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                               >
                                 <span
                                   class="css-1f43avz-a11yText-A11yText"
-                                  id="react-select-27-live-region"
+                                  id="react-select-36-live-region"
                                 />
                                 <span
                                   aria-atomic="false"
@@ -746,7 +746,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                   >
                                     <div
                                       class="search-form-select__placeholder css-1jqq78o-placeholder"
-                                      id="react-select-27-placeholder"
+                                      id="react-select-36-placeholder"
                                     >
                                       Modifier
                                     </div>
@@ -757,7 +757,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                       <input
                                         aria-activedescendant=""
                                         aria-autocomplete="list"
-                                        aria-describedby="react-select-27-placeholder"
+                                        aria-describedby="react-select-36-placeholder"
                                         aria-expanded="false"
                                         aria-haspopup="true"
                                         aria-label="select-period-modifier"
@@ -765,7 +765,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                         autocomplete="off"
                                         autocorrect="off"
                                         class="search-form-select__input"
-                                        id="react-select-27-input"
+                                        id="react-select-36-input"
                                         role="combobox"
                                         spellcheck="false"
                                         style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -825,7 +825,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                           >
                             <span
                               class="css-1f43avz-a11yText-A11yText"
-                              id="react-select-28-live-region"
+                              id="react-select-37-live-region"
                             />
                             <span
                               aria-atomic="false"
@@ -842,7 +842,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                               >
                                 <div
                                   class="provenance-selector__placeholder css-1jqq78o-placeholder"
-                                  id="react-select-28-placeholder"
+                                  id="react-select-37-placeholder"
                                 >
                                   Provenance
                                 </div>
@@ -853,7 +853,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                   <input
                                     aria-activedescendant=""
                                     aria-autocomplete="list"
-                                    aria-describedby="react-select-28-placeholder"
+                                    aria-describedby="react-select-37-placeholder"
                                     aria-expanded="false"
                                     aria-haspopup="true"
                                     aria-label="select-site"
@@ -861,7 +861,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                     autocomplete="off"
                                     autocorrect="off"
                                     class="provenance-selector__input"
-                                    id="react-select-28-input"
+                                    id="react-select-37-input"
                                     role="combobox"
                                     spellcheck="false"
                                     style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -920,7 +920,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                           >
                             <span
                               class="css-1f43avz-a11yText-A11yText"
-                              id="react-select-22-live-region"
+                              id="react-select-31-live-region"
                             />
                             <span
                               aria-atomic="false"
@@ -937,7 +937,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                               >
                                 <div
                                   class="css-1jqq78o-placeholder"
-                                  id="react-select-22-placeholder"
+                                  id="react-select-31-placeholder"
                                 >
                                   Dossiers
                                 </div>
@@ -948,7 +948,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                   <input
                                     aria-activedescendant=""
                                     aria-autocomplete="list"
-                                    aria-describedby="react-select-22-placeholder"
+                                    aria-describedby="react-select-31-placeholder"
                                     aria-expanded="false"
                                     aria-haspopup="true"
                                     aria-label="Dossier"
@@ -956,7 +956,7 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
                                     autocomplete="off"
                                     autocorrect="off"
                                     class=""
-                                    id="react-select-22-input"
+                                    id="react-select-31-input"
                                     role="combobox"
                                     spellcheck="false"
                                     style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -1062,11 +1062,11 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
             role="presentation"
           >
             <button
-              aria-controls="react-aria-:r2:-tabpane-library"
+              aria-controls="react-aria-:r3:-tabpane-library"
               aria-selected="true"
               class="nav-link active"
               data-rr-ui-event-key="library"
-              id="react-aria-:r2:-tab-library"
+              id="react-aria-:r3:-tab-library"
               role="tab"
               type="button"
             >
@@ -1078,11 +1078,11 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
             role="presentation"
           >
             <button
-              aria-controls="react-aria-:r2:-tabpane-corpus"
+              aria-controls="react-aria-:r3:-tabpane-corpus"
               aria-selected="false"
               class="nav-link"
               data-rr-ui-event-key="corpus"
-              id="react-aria-:r2:-tab-corpus"
+              id="react-aria-:r3:-tab-corpus"
               role="tab"
               tabindex="-1"
               type="button"
@@ -1095,9 +1095,9 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
           class="tab-content"
         >
           <div
-            aria-labelledby="react-aria-:r2:-tab-library"
+            aria-labelledby="react-aria-:r3:-tab-library"
             class="fade tab-pane active show"
-            id="react-aria-:r2:-tabpane-library"
+            id="react-aria-:r3:-tabpane-library"
             role="tabpanel"
           >
             <div
@@ -1120,9 +1120,9 @@ exports[`Search Shows suggestion when entering wrong number format 1`] = `
             </div>
           </div>
           <div
-            aria-labelledby="react-aria-:r2:-tab-corpus"
+            aria-labelledby="react-aria-:r3:-tab-corpus"
             class="fade tab-pane"
-            id="react-aria-:r2:-tabpane-corpus"
+            id="react-aria-:r3:-tabpane-corpus"
             role="tabpanel"
           >
             <div

--- a/src/query/QueryResult.ts
+++ b/src/query/QueryResult.ts
@@ -1,14 +1,17 @@
+import { Fragment } from 'fragmentarium/domain/fragment'
 import { TextId } from 'transliteration/domain/text-id'
 
 export interface QueryItem {
-  museumNumber: string
-  matchingLines: readonly number[]
-  matchCount: number
+  readonly museumNumber: string
+  readonly matchingLines: readonly number[]
+  readonly matchCount: number
+  readonly fragment?: Fragment
+  readonly thumbnailPath?: string | null
 }
 
 export interface QueryResult {
-  items: readonly QueryItem[]
-  matchCountTotal: number
+  readonly items: readonly QueryItem[]
+  readonly matchCountTotal: number
 }
 
 export interface CorpusQueryItem {

--- a/src/query/QueryResult.ts
+++ b/src/query/QueryResult.ts
@@ -11,7 +11,9 @@ export interface QueryItem {
 
 export interface QueryResult {
   readonly items: readonly QueryItem[]
-  readonly matchCountTotal: number
+  readonly matchCountTotal: number | null
+  readonly isMatchCountTotalExact?: boolean
+  readonly hasNextPage?: boolean | null
 }
 
 export interface CorpusQueryItem {
@@ -25,7 +27,9 @@ export interface CorpusQueryItem {
 
 export interface CorpusQueryResult {
   items: readonly CorpusQueryItem[]
-  matchCountTotal: number
+  matchCountTotal: number | null
+  isMatchCountTotalExact?: boolean
+  hasNextPage?: boolean | null
 }
 
 export interface FragmentAfoRegisterQueryItem {


### PR DESCRIPTION
## Summary

- Render fragment search results from backend-provided summary data, avoiding a separate fragment request for every result.
- Preserve compatibility with legacy query items by falling back to per-fragment hydration when no summary fragment is present.
- Fix cancelled in-flight cache reuse and stabilize `withData` watch keys.
- Add coverage for summary-backed search results and compatibility paths.

## Backend contract

This frontend change depends on fragment query responses optionally returning summary fields including `description`, `script`, `hasPhoto`, `matchingLinePreview`, and `thumbnailPath`. The backend contract does not currently provide an explicit `type`/`kind` discriminator, so the frontend uses those required summary fields for structural detection while retaining the legacy response path.