### PR TITLE
fix: pagination

### DIFF
--- a/src/fragmentarium/ui/search/FragmentariumSearchResult.test.tsx
+++ b/src/fragmentarium/ui/search/FragmentariumSearchResult.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, useLocation } from 'react-router-dom'
 import { SearchResult } from './FragmentariumSearchResult'
@@ -81,10 +81,22 @@ describe('FragmentariumSearchResult pagination', () => {
     },
   )
 
-  it('clamps out-of-range paginationIndex to the last page', async () => {
+  it('uses the first paginationIndex when the URL contains multiple values', async () => {
+    renderSearchResult('?paginationIndex=5&paginationIndex=1')
+
+    expect(await screen.findByText('K.251')).toBeInTheDocument()
+    expect(screen.queryByText('K.51')).not.toBeInTheDocument()
+  })
+
+  it('clamps out-of-range paginationIndex to the last page and normalizes the URL', async () => {
     renderSearchResult('?paginationIndex=9999')
 
     expect(await screen.findByText('K.451')).toBeInTheDocument()
     expect(screen.queryByText('K.1')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent(
+        'paginationIndex=9',
+      )
+    })
   })
 })

--- a/src/fragmentarium/ui/search/FragmentariumSearchResult.test.tsx
+++ b/src/fragmentarium/ui/search/FragmentariumSearchResult.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+import { SearchResult } from './FragmentariumSearchResult'
+import FragmentService from 'fragmentarium/application/FragmentService'
+import DossiersService from 'dossiers/application/DossiersService'
+import { QueryItem, QueryResult } from 'query/QueryResult'
+
+jest.mock(
+  'fragmentarium/ui/search/FragmentariumSearchResultComponents',
+  () => ({
+    FragmentLines: ({ queryItem }: { queryItem: QueryItem }) => (
+      <div>{queryItem.museumNumber}</div>
+    ),
+  }),
+)
+
+function LocationDisplay(): JSX.Element {
+  const location = useLocation()
+  return <div data-testid="location">{location.search}</div>
+}
+
+function buildQueryResult(totalItems = 500): QueryResult {
+  return {
+    items: Array.from({ length: totalItems }, (_, index) => ({
+      museumNumber: `K.${index + 1}`,
+      matchingLines: [],
+      matchCount: 0,
+    })),
+    matchCountTotal: 0,
+  }
+}
+
+function renderSearchResult(search = ''): jest.Mocked<FragmentService> {
+  const fragmentService = {
+    query: jest.fn().mockResolvedValue(buildQueryResult()),
+  } as unknown as jest.Mocked<FragmentService>
+
+  render(
+    <MemoryRouter initialEntries={[`/library/search/${search}`]}>
+      <LocationDisplay />
+      <SearchResult
+        fragmentService={fragmentService}
+        dossiersService={{} as DossiersService}
+        fragmentQuery={{ number: 'K.1' }}
+      />
+    </MemoryRouter>,
+  )
+
+  return fragmentService
+}
+
+describe('FragmentariumSearchResult pagination', () => {
+  it('starts on page 6 when paginationIndex=5', async () => {
+    renderSearchResult('?paginationIndex=5')
+
+    expect(await screen.findByText('K.251')).toBeInTheDocument()
+    expect(screen.queryByText('K.1')).not.toBeInTheDocument()
+  })
+
+  it('updates the URL when clicking page 10', async () => {
+    renderSearchResult()
+
+    await screen.findByText('K.1')
+    await userEvent.click(screen.getAllByRole('button', { name: '10' })[0])
+
+    expect(await screen.findByText('K.451')).toBeInTheDocument()
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      'paginationIndex=9',
+    )
+  })
+
+  it.each(['?paginationIndex=abc', '?paginationIndex=-5'])(
+    'defaults to page 1 for invalid pagination value %s',
+    async (search) => {
+      renderSearchResult(search)
+
+      expect(await screen.findByText('K.1')).toBeInTheDocument()
+      expect(screen.queryByText('K.51')).not.toBeInTheDocument()
+    },
+  )
+
+  it('clamps out-of-range paginationIndex to the last page', async () => {
+    renderSearchResult('?paginationIndex=9999')
+
+    expect(await screen.findByText('K.451')).toBeInTheDocument()
+    expect(screen.queryByText('K.1')).not.toBeInTheDocument()
+  })
+})

--- a/src/fragmentarium/ui/search/FragmentariumSearchResult.tsx
+++ b/src/fragmentarium/ui/search/FragmentariumSearchResult.tsx
@@ -27,7 +27,7 @@ export function getActivePageFromSearch(
 ): number {
   const parsedPaginationIndex = getRequestedPaginationIndex(search)
 
-  if (!Number.isFinite(parsedPaginationIndex)) {
+  if (parsedPaginationIndex === undefined) {
     return 0
   }
 
@@ -62,7 +62,7 @@ function ResultPages({
 
   useEffect(() => {
     if (
-      Number.isFinite(requestedPaginationIndex) &&
+      requestedPaginationIndex !== undefined &&
       requestedPaginationIndex > lastPage
     ) {
       history.replace({

--- a/src/fragmentarium/ui/search/FragmentariumSearchResult.tsx
+++ b/src/fragmentarium/ui/search/FragmentariumSearchResult.tsx
@@ -7,34 +7,31 @@ import { Col, Row } from 'react-bootstrap'
 import { FragmentQuery } from 'query/FragmentQuery'
 import { linesToShow } from './FragmentariumSearch'
 import './FragmentariumSearchResult.sass'
-import { parse, stringify } from 'query-string'
+import { stringify } from 'query-string'
 import { FragmentLines } from './FragmentariumSearchResultComponents'
 import DossiersService from 'dossiers/application/DossiersService'
 import PaginationItems from './PaginationItems'
 import { useLocation } from 'react-router-dom'
+import { useHistory } from 'router/compat'
+import {
+  getRequestedPaginationIndex,
+  paginationURLParam,
+  updatePaginationSearchParam,
+} from './pagination'
 
-const paginationURLParam = 'paginationIndex'
 const RESULTS_PER_PAGE = 50
 
 export function getActivePageFromSearch(
   search: string,
   lastPage: number,
 ): number {
-  const query = parse(search, {
-    parseNumbers: true,
-  })
-  const paginationIndex = _.isArray(query[paginationURLParam])
-    ? query[paginationURLParam][0]
-    : query[paginationURLParam]
-  const parsedPaginationIndex = _.isNumber(paginationIndex)
-    ? paginationIndex
-    : Number(paginationIndex)
+  const parsedPaginationIndex = getRequestedPaginationIndex(search)
 
   if (!Number.isFinite(parsedPaginationIndex)) {
     return 0
   }
 
-  return _.clamp(Math.trunc(parsedPaginationIndex), 0, lastPage)
+  return _.clamp(parsedPaginationIndex, 0, lastPage)
 }
 
 function ResultPages({
@@ -51,15 +48,32 @@ function ResultPages({
   queryLemmas?: readonly string[]
 }): JSX.Element {
   const location = useLocation()
+  const history = useHistory()
   const pages = _.chunk(fragments, RESULTS_PER_PAGE)
   const lastPage = pages.length - 1
   const initialActivePage = getActivePageFromSearch(location.search, lastPage)
+  const requestedPaginationIndex = getRequestedPaginationIndex(location.search)
   const [active, setActive] = useState(initialActivePage)
   const displayActive = _.clamp(active, 0, lastPage)
 
   useEffect(() => {
     setActive(initialActivePage)
   }, [initialActivePage])
+
+  useEffect(() => {
+    if (
+      Number.isFinite(requestedPaginationIndex) &&
+      requestedPaginationIndex > lastPage
+    ) {
+      history.replace({
+        search: updatePaginationSearchParam(
+          location.search,
+          paginationURLParam,
+          lastPage,
+        ),
+      })
+    }
+  }, [history, lastPage, location.search, requestedPaginationIndex])
 
   const pageButtons = (
     <Row>

--- a/src/fragmentarium/ui/search/FragmentariumSearchResult.tsx
+++ b/src/fragmentarium/ui/search/FragmentariumSearchResult.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import _ from 'lodash'
 import FragmentService from 'fragmentarium/application/FragmentService'
 import withData from 'http/withData'
@@ -7,10 +7,35 @@ import { Col, Row } from 'react-bootstrap'
 import { FragmentQuery } from 'query/FragmentQuery'
 import { linesToShow } from './FragmentariumSearch'
 import './FragmentariumSearchResult.sass'
-import { stringify } from 'query-string'
-import { ResultPageButtons } from 'common/ui/ResultPageButtons'
+import { parse, stringify } from 'query-string'
 import { FragmentLines } from './FragmentariumSearchResultComponents'
 import DossiersService from 'dossiers/application/DossiersService'
+import PaginationItems from './PaginationItems'
+import { useLocation } from 'react-router-dom'
+
+const paginationURLParam = 'paginationIndex'
+const RESULTS_PER_PAGE = 50
+
+export function getActivePageFromSearch(
+  search: string,
+  lastPage: number,
+): number {
+  const query = parse(search, {
+    parseNumbers: true,
+  })
+  const paginationIndex = _.isArray(query[paginationURLParam])
+    ? query[paginationURLParam][0]
+    : query[paginationURLParam]
+  const parsedPaginationIndex = _.isNumber(paginationIndex)
+    ? paginationIndex
+    : Number(paginationIndex)
+
+  if (!Number.isFinite(parsedPaginationIndex)) {
+    return 0
+  }
+
+  return _.clamp(Math.trunc(parsedPaginationIndex), 0, lastPage)
+}
 
 function ResultPages({
   fragments,
@@ -25,18 +50,34 @@ function ResultPages({
   linesToShow: number
   queryLemmas?: readonly string[]
 }): JSX.Element {
-  const [active, setActive] = useState(0)
-  const RESULTS_PER_PAGE = 50
+  const location = useLocation()
   const pages = _.chunk(fragments, RESULTS_PER_PAGE)
+  const lastPage = pages.length - 1
+  const initialActivePage = getActivePageFromSearch(location.search, lastPage)
+  const [active, setActive] = useState(initialActivePage)
+  const displayActive = _.clamp(active, 0, lastPage)
+
+  useEffect(() => {
+    setActive(initialActivePage)
+  }, [initialActivePage])
 
   const pageButtons = (
-    <ResultPageButtons pages={pages} active={active} setActive={setActive} />
+    <Row>
+      <Col className="d-flex justify-content-center">
+        <PaginationItems
+          activePage={displayActive}
+          lastPage={lastPage}
+          setActivePage={setActive}
+          paginationURLParam={paginationURLParam}
+        />
+      </Col>
+    </Row>
   )
 
   return (
     <>
       {pageButtons}
-      {pages[active].map((fragment) => (
+      {pages[displayActive].map((fragment) => (
         <React.Fragment
           key={`${fragment.museumNumber}:${fragment.matchingLines.join(',')}`}
         >
@@ -44,7 +85,7 @@ function ResultPages({
             fragmentService={fragmentService}
             dossiersService={dossiersService}
             queryItem={fragment}
-            active={active}
+            active={displayActive}
             queryLemmas={queryLemmas}
             linesToShow={linesToShow}
           />
@@ -117,6 +158,6 @@ export const SearchResult = withData<
   },
   ({ fragmentService, fragmentQuery }) => fragmentService.query(fragmentQuery),
   {
-    watch: ({ fragmentQuery }) => [fragmentQuery],
+    watch: ({ fragmentQuery }) => [stringify(fragmentQuery)],
   },
 )

--- a/src/fragmentarium/ui/search/PaginationItems.test.tsx
+++ b/src/fragmentarium/ui/search/PaginationItems.test.tsx
@@ -174,4 +174,19 @@ describe('Click through Pagination Component End', () => {
         'museum=BM&number=000123&genre=CANONICAL%3ATechnical%3AAstronomy%3AAstronomical%20Diaries&paginationIndex=1',
     })
   })
+
+  it('removes duplicate paginationIndex params when paginating', async () => {
+    renderPaginationItems(
+      4,
+      99,
+      '/library/search/?museum=BM&paginationIndex=4&genre=letters&paginationIndex=99',
+    )
+
+    await screen.findByText('5')
+    await userEvent.click(screen.getByRole('button', { name: '2' }))
+
+    expect(mockHistoryPush).toHaveBeenLastCalledWith({
+      search: 'museum=BM&paginationIndex=1&genre=letters',
+    })
+  })
 })

--- a/src/fragmentarium/ui/search/PaginationItems.test.tsx
+++ b/src/fragmentarium/ui/search/PaginationItems.test.tsx
@@ -34,9 +34,13 @@ function PaginationItemsWrapper({
   )
 }
 
-function renderPaginationItems(startPage = 0, totalPages: number) {
+function renderPaginationItems(
+  startPage = 0,
+  totalPages: number,
+  initialEntry = '/library/search/',
+) {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <PaginationItemsWrapper startPage={startPage} totalPages={totalPages} />
     </MemoryRouter>,
   )
@@ -153,5 +157,21 @@ describe('Click through Pagination Component End', () => {
       })
     }
     expect(screen.queryByRole('button', { name: '95' })).not.toBeInTheDocument()
+  })
+
+  it('preserves existing numeric text and encoded query values when paginating', async () => {
+    renderPaginationItems(
+      0,
+      99,
+      '/library/search/?museum=BM&number=000123&genre=CANONICAL%3ATechnical%3AAstronomy%3AAstronomical%20Diaries',
+    )
+
+    await screen.findByText('1')
+    await userEvent.click(screen.getByRole('button', { name: '2' }))
+
+    expect(mockHistoryPush).toHaveBeenLastCalledWith({
+      search:
+        'museum=BM&number=000123&genre=CANONICAL%3ATechnical%3AAstronomy%3AAstronomical%20Diaries&paginationIndex=1',
+    })
   })
 })

--- a/src/fragmentarium/ui/search/PaginationItems.tsx
+++ b/src/fragmentarium/ui/search/PaginationItems.tsx
@@ -3,41 +3,9 @@ import { Pagination } from 'react-bootstrap'
 import { useLocation } from 'react-router-dom'
 import { useHistory } from 'router/compat'
 import _ from 'lodash'
+import { updatePaginationSearchParam } from './pagination'
 
 const NEIGHBOURING_PAGINATION_ITEMS = 3
-
-function updatePaginationSearchParam(
-  search: string,
-  paginationURLParam: string,
-  index: number,
-): string {
-  const params = search.replace(/^\?/, '').split('&').filter(Boolean)
-  const paginationParam = `${encodeURIComponent(
-    paginationURLParam,
-  )}=${encodeURIComponent(index.toString())}`
-  let updated = false
-
-  const nextParams = params.flatMap((param) => {
-    const [key] = param.split('=')
-
-    if (key !== encodeURIComponent(paginationURLParam)) {
-      return [param]
-    }
-
-    if (!updated) {
-      updated = true
-      return [paginationParam]
-    }
-
-    return []
-  })
-
-  if (!updated) {
-    nextParams.push(paginationParam)
-  }
-
-  return nextParams.join('&')
-}
 
 function PaginationItem({
   paginationURLParam,

--- a/src/fragmentarium/ui/search/PaginationItems.tsx
+++ b/src/fragmentarium/ui/search/PaginationItems.tsx
@@ -1,11 +1,43 @@
 import React from 'react'
 import { Pagination } from 'react-bootstrap'
-import { parse, stringify } from 'query-string'
 import { useLocation } from 'react-router-dom'
 import { useHistory } from 'router/compat'
 import _ from 'lodash'
 
 const NEIGHBOURING_PAGINATION_ITEMS = 3
+
+function updatePaginationSearchParam(
+  search: string,
+  paginationURLParam: string,
+  index: number,
+): string {
+  const params = search.replace(/^\?/, '').split('&').filter(Boolean)
+  const paginationParam = `${encodeURIComponent(
+    paginationURLParam,
+  )}=${encodeURIComponent(index.toString())}`
+  let updated = false
+
+  const nextParams = params.flatMap((param) => {
+    const [key] = param.split('=')
+
+    if (key !== encodeURIComponent(paginationURLParam)) {
+      return [param]
+    }
+
+    if (!updated) {
+      updated = true
+      return [paginationParam]
+    }
+
+    return []
+  })
+
+  if (!updated) {
+    nextParams.push(paginationParam)
+  }
+
+  return nextParams.join('&')
+}
 
 function PaginationItem({
   paginationURLParam,
@@ -25,13 +57,13 @@ function PaginationItem({
       active={active}
       onClick={(event) => {
         event.preventDefault()
-        const query = parse(location.search, {
-          parseNumbers: true,
-        })
         setActivePage(index)
-        query[paginationURLParam] = index
         history.push({
-          search: stringify({ ...query }),
+          search: updatePaginationSearchParam(
+            location.search,
+            paginationURLParam,
+            index,
+          ),
         })
       }}
     >

--- a/src/fragmentarium/ui/search/pagination.ts
+++ b/src/fragmentarium/ui/search/pagination.ts
@@ -1,0 +1,55 @@
+import _ from 'lodash'
+import { parse } from 'query-string'
+
+export const paginationURLParam = 'paginationIndex'
+
+export function getRequestedPaginationIndex(
+  search: string,
+): number | undefined {
+  const query = parse(search, {
+    parseNumbers: true,
+  })
+  const paginationIndex = _.isArray(query[paginationURLParam])
+    ? query[paginationURLParam][0]
+    : query[paginationURLParam]
+  const parsedPaginationIndex = _.isNumber(paginationIndex)
+    ? paginationIndex
+    : Number(paginationIndex)
+
+  return Number.isFinite(parsedPaginationIndex)
+    ? Math.trunc(parsedPaginationIndex)
+    : undefined
+}
+
+export function updatePaginationSearchParam(
+  search: string,
+  param: string,
+  index: number,
+): string {
+  const params = search.replace(/^\?/, '').split('&').filter(Boolean)
+  const paginationParam = `${encodeURIComponent(param)}=${encodeURIComponent(
+    index.toString(),
+  )}`
+  let updated = false
+
+  const nextParams = params.flatMap((searchParam) => {
+    const [key] = searchParam.split('=')
+
+    if (key !== encodeURIComponent(param)) {
+      return [searchParam]
+    }
+
+    if (!updated) {
+      updated = true
+      return [paginationParam]
+    }
+
+    return []
+  })
+
+  if (!updated) {
+    nextParams.push(paginationParam)
+  }
+
+  return nextParams.join('&')
+}

--- a/src/router/fragmentariumRoutes.pagination.test.tsx
+++ b/src/router/fragmentariumRoutes.pagination.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+import { Switch } from 'router/compat'
+import SessionContext from 'auth/SessionContext'
+import MemorySession from 'auth/Session'
+import FragmentariumRoutes from './fragmentariumRoutes'
+import FragmentService from 'fragmentarium/application/FragmentService'
+import FragmentSearchService from 'fragmentarium/application/FragmentSearchService'
+import BibliographyService from 'bibliography/application/BibliographyService'
+import WordService from 'dictionary/application/WordService'
+import TextService from 'corpus/application/TextService'
+import DossiersService from 'dossiers/application/DossiersService'
+import { QueryItem, QueryResult } from 'query/QueryResult'
+import { FindspotService } from 'fragmentarium/application/FindspotService'
+import AfoRegisterService from 'afo-register/application/AfoRegisterService'
+import SignService from 'signs/application/SignService'
+
+jest.mock('router/head', () => ({
+  __esModule: true,
+  HeadTagsService: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}))
+
+jest.mock(
+  'fragmentarium/ui/search/FragmentariumSearchResultComponents',
+  () => ({
+    FragmentLines: ({ queryItem }: { queryItem: QueryItem }) => (
+      <div>{queryItem.museumNumber}</div>
+    ),
+  }),
+)
+
+function LocationDisplay(): JSX.Element {
+  const location = useLocation()
+  return <div data-testid="location">{location.search}</div>
+}
+
+function buildQueryResult(totalItems = 500): QueryResult {
+  return {
+    items: Array.from({ length: totalItems }, (_, index) => ({
+      museumNumber: `K.${index + 1}`,
+      matchingLines: [],
+      matchCount: 0,
+    })),
+    matchCountTotal: 0,
+  }
+}
+
+describe('FragmentariumRoutes library search pagination', () => {
+  it('keeps paginationIndex out of the backend query and does not refetch on page changes', async () => {
+    const fragmentService = {
+      query: jest.fn().mockResolvedValue(buildQueryResult()),
+      fetchPeriods: jest.fn().mockResolvedValue([]),
+      fetchGenres: jest.fn().mockResolvedValue([]),
+      fetchProvenances: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<FragmentService>
+    const textService = {
+      query: jest.fn().mockResolvedValue({ items: [], matchCountTotal: 0 }),
+    } as unknown as jest.Mocked<TextService>
+    const dossiersService = {
+      fetchFilteredDossiers: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<DossiersService>
+    const wordService = {
+      findAll: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<WordService>
+
+    render(
+      <MemoryRouter
+        initialEntries={['/library/search/?number=K.1&paginationIndex=5']}
+      >
+        <SessionContext.Provider value={new MemorySession(['read:fragments'])}>
+          <LocationDisplay />
+          <Switch>
+            {FragmentariumRoutes({
+              sitemap: false,
+              fragmentService,
+              fragmentSearchService: {} as FragmentSearchService,
+              textService,
+              wordService,
+              findspotService: {} as FindspotService,
+              afoRegisterService: {} as AfoRegisterService,
+              dossiersService,
+              signService: {} as SignService,
+              bibliographyService: {} as BibliographyService,
+            })}
+          </Switch>
+        </SessionContext.Provider>
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('K.251')).toBeInTheDocument()
+    expect(fragmentService.query).toHaveBeenCalledWith({ number: 'K.1' })
+    expect(fragmentService.query).toHaveBeenCalledTimes(1)
+
+    await userEvent.click(screen.getAllByRole('button', { name: '10' })[0])
+
+    expect(await screen.findByText('K.451')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent(
+        'paginationIndex=9',
+      )
+    })
+    expect(fragmentService.query).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/router/fragmentariumRoutes.tsx
+++ b/src/router/fragmentariumRoutes.tsx
@@ -23,8 +23,7 @@ import NotFoundPage from 'NotFoundPage'
 import DossiersService from 'dossiers/application/DossiersService'
 import RecordView from 'fragmentarium/ui/fragment/RecordView'
 import { FragmentQuery } from 'query/FragmentQuery'
-
-const paginationURLParam = 'paginationIndex'
+import { paginationURLParam } from 'fragmentarium/ui/search/pagination'
 
 function parseStringParam(location: Location, param: string): string | null {
   const value = parse(location.search)[param]

--- a/src/router/fragmentariumRoutes.tsx
+++ b/src/router/fragmentariumRoutes.tsx
@@ -22,6 +22,9 @@ import AfoRegisterService from 'afo-register/application/AfoRegisterService'
 import NotFoundPage from 'NotFoundPage'
 import DossiersService from 'dossiers/application/DossiersService'
 import RecordView from 'fragmentarium/ui/fragment/RecordView'
+import { FragmentQuery } from 'query/FragmentQuery'
+
+const paginationURLParam = 'paginationIndex'
 
 function parseStringParam(location: Location, param: string): string | null {
   const value = parse(location.search)[param]
@@ -87,9 +90,14 @@ export default function FragmentariumRoutes({
           <FragmentariumSearch
             fragmentSearchService={fragmentSearchService}
             fragmentService={fragmentService}
-            fragmentQuery={parse(routeProps.location.search, {
-              decode: true,
-            })}
+            fragmentQuery={
+              _.omit(
+                parse(routeProps.location.search, {
+                  decode: true,
+                }),
+                paginationURLParam,
+              ) as FragmentQuery
+            }
             bibliographyService={bibliographyService}
             wordService={wordService}
             textService={textService}


### PR DESCRIPTION
Add URL-backed pagination for Library search results. We use frontend-only query params such as `paginationIndex`. Keep pagination 0-based internally and display page numbers as 1-based. Clicking a pagination button should update URL and refreshing should preserve the active page. 