### PR TITLE
Run sitemap automation under its own bot identity

### DIFF
--- a/.github/workflows/update-sitemaps.yml
+++ b/.github/workflows/update-sitemaps.yml
@@ -5,11 +5,31 @@ on:
     - cron: '0 1 * * 0'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-sitemap:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate automation app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.EBL_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.EBL_AUTOMATION_PRIVATE_KEY }}
+
+      - name: Resolve automation app identity
+        id: app-identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          app_user_id=$(gh api "/users/${APP_SLUG}%5Bbot%5D" --jq .id)
+          echo "name=${APP_SLUG}[bot]" >> "$GITHUB_OUTPUT"
+          echo "email=${app_user_id}+${APP_SLUG}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -56,27 +76,15 @@ jobs:
       - name: Remove temporary environment
         run: rm -rf tmp-script-env
 
-      - name: Commit sitemap changes
-        id: commit
-        run: |
-          git config user.name "Ilya Khait"
-          git config user.email "ilya.khait@lmu.de"
-          git add public/sitemap
-          if git diff --cached --quiet; then
-            echo "No changes to commit."
-            echo "commit-needed=false" >> $GITHUB_OUTPUT
-          else
-            git commit -m "Update sitemap files"
-            echo "commit-needed=true" >> $GITHUB_OUTPUT
-          fi
-
       - name: Create Pull Request
-        if: steps.commit.outputs.commit-needed == 'true'
         id: create-pull-request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.SITEMAP_AUTOUPDATE }}
+          token: ${{ steps.app-token.outputs.token }}
+          add-paths: public/sitemap
           commit-message: Update sitemap files
+          committer: ${{ steps.app-identity.outputs.name }} <${{ steps.app-identity.outputs.email }}>
+          author: ${{ steps.app-identity.outputs.name }} <${{ steps.app-identity.outputs.email }}>
           title: 'Automated sitemap update'
           body: 'This PR was created automatically by a GitHub Action to update sitemap files.'
           base: master
@@ -87,6 +95,6 @@ jobs:
         if: steps.create-pull-request.outputs.pull-request-number != ''
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ secrets.SITEMAP_AUTOUPDATE }}
+          token: ${{ steps.app-token.outputs.token }}
           pull-request-number: ${{ steps.create-pull-request.outputs.pull-request-number }}
           merge-method: squash

--- a/TASK-sitemap-automerge-log.md
+++ b/TASK-sitemap-automerge-log.md
@@ -1,0 +1,252 @@
+# TASK-sitemap-automerge — Work Log
+
+## Summary
+
+The weekly "Automated sitemap update" pull requests are blocked by master branch
+protection because they are authored by the `khoidt` account. GitHub does not allow a
+user to approve their own pull request, and admin bypass is disabled on the repository,
+so the one person who could merge them is the one person who cannot. Auto-merge is armed
+on both stuck PRs and is waiting for an approving review that will never arrive.
+
+## Evidence
+
+Collected 2026-08-04 against `ElectronicBabylonianLiterature/ebl-frontend`.
+
+### The automation
+
+`.github/workflows/update-sitemaps.yml` runs weekly (`cron: '0 1 * * 0'`). It regenerates
+`public/sitemap/*`, commits with `git config user.name "Ilya Khait"` /
+`ilya.khait@lmu.de`, then opens a PR with `peter-evans/create-pull-request@v5` using
+`token: ${{ secrets.SITEMAP_AUTOUPDATE }}`, and finally arms auto-merge (squash) with
+`peter-evans/enable-pull-request-automerge@v3` using the same token.
+
+`secrets.SITEMAP_AUTOUPDATE` is a personal access token belonging to `khoidt`, so the
+resulting pull request is authored by `khoidt`, not by a bot.
+
+### Stuck pull requests
+
+| PR   | Opened     | Head branch                      | Author   |
+| ---- | ---------- | -------------------------------- | -------- |
+| #775 | 2026-07-26 | `autoupdate-sitemap-30187853818` | `khoidt` |
+| #778 | 2026-08-02 | `autoupdate-sitemap-30732345074` | `khoidt` |
+
+Last successfully merged sitemap PR: **#772 on 2026-07-19** (`4db5c9cd`). Every weekly run
+before that merged normally, so master protection was tightened between 2026-07-19 and
+2026-07-26.
+
+### The blocker is the review requirement, not CI
+
+All required checks are green on both head commits (`31900c5b`, `980f3c01`):
+
+- check runs: `test`, `CodeQL`, `Analyze (javascript)`, `GitGuardian scan`,
+  `GitGuardian Security Checks` — all `success`; `docker` / `docker-test` correctly
+  `skipped` (they are gated on `push` to master)
+- combined commit status: `success` (`qlty check`, `qlty coverage`, `qlty coverage diff`)
+
+GraphQL on both PRs returns:
+
+```text
+mergeStateStatus: BLOCKED
+reviewDecision:   REVIEW_REQUIRED
+viewerDidAuthor:  true
+autoMergeRequest: enabled by khoidt, squash
+```
+
+REST `mergeable: true`, `mergeable_state: "blocked"` — no conflicts, protection is the
+only obstacle.
+
+### Why the reporter cannot merge either
+
+`viewerPermission: ADMIN`, `viewerCanAdminister: true` — yet the merge is still blocked.
+That means master protection has "Do not allow bypassing the above settings"
+(admin enforcement) enabled, so the admin escape hatch is deliberately closed. Combined
+with GitHub's prohibition on self-approval, `khoidt` has no path to merge their own PR.
+
+Other repository admins who _can_ approve: `jlaasonen`, `fsimonjetz`, `ejimsan`,
+`yCobanoglu`. Any of them approving unblocks the armed auto-merge immediately.
+
+### Why the obvious fix does not work
+
+Switching the workflow to `secrets.GITHUB_TOKEN` would make the PR author
+`github-actions[bot]` and solve the authorship problem — but pull requests opened with the
+default `GITHUB_TOKEN` deliberately do **not** trigger further workflow runs. `main.yml`,
+CodeQL and the secret scan would never run, the required status checks would sit
+permanently pending, and the PR would be _more_ stuck than it is now. This is almost
+certainly why a PAT was used in the first place.
+
+### Protection mechanism in use
+
+`GET /repos/.../rulesets` returns `[]` — there are no repository rulesets. Master is
+protected by **classic branch protection**. Reading the rule detail is not possible with
+the token available here (`Resource not accessible by integration` on both
+`/branches/master/protection` and `branchProtectionRules`), but the observed behaviour
+pins it down: require a PR, require ≥1 approving review, require status checks, admin
+enforcement on.
+
+## Root cause
+
+The automation's identity and the merge authority's identity are the same account. Branch
+protection that requires an independent approving review is, by design, unsatisfiable when
+the author is the only reviewer available — and admin enforcement removes the fallback.
+
+## Options
+
+### Option A — Give the automation its own bot identity (recommended baseline)
+
+Create an organisation-owned GitHub App (e.g. "eBL Automation") with repository
+permissions **Contents: read & write** and **Pull requests: read & write**, install it on
+`ebl-frontend`, and store `EBL_AUTOMATION_APP_ID` + `EBL_AUTOMATION_PRIVATE_KEY` as repository secrets.
+In the workflow, mint a short-lived installation token and use it in place of the PAT:
+
+```yaml
+- name: Mint bot token
+  id: bot-token
+  uses: actions/create-github-app-token@v3
+  with:
+    app-id: ${{ secrets.EBL_AUTOMATION_APP_ID }}
+    private-key: ${{ secrets.EBL_AUTOMATION_PRIVATE_KEY }}
+```
+
+Also change the commit identity in the "Commit sitemap changes" step from
+`Ilya Khait <ilya.khait@lmu.de>` to the bot, so the commits are not attributed to a person
+either.
+
+Effects:
+
+- PR author becomes `ebl-automation[bot]`, so `khoidt` — and every other maintainer — can
+  approve and merge it. This satisfies the "at least let me merge them myself" requirement.
+- Installation tokens are **not** the default `GITHUB_TOKEN`, so `pull_request` workflows
+  still fire and the required checks still run.
+- Master branch protection is untouched.
+- The PAT disappears from the repository, which is a security improvement: a repo-scoped
+  PAT tied to a human admin is replaced by a scoped, short-lived, auto-expiring token.
+
+Cost: one approving click per week, from anyone.
+
+### Option B — Option A plus a bypass, for genuinely unattended merging
+
+On top of Option A, migrate master's protection from classic branch protection to a
+**repository ruleset** carrying the same rules, and add the GitHub App as a **bypass
+actor**. Human pull requests keep needing review and green checks; the bot's PR merges
+itself through the already-armed auto-merge.
+
+This is the only route to full automation that keeps protection meaningful, because
+classic branch protection's bypass list
+(`bypass_pull_request_allowances`) only grants the right to _push directly_ to master — it
+does not make an under-reviewed PR mergeable. Rulesets exempt bypass actors from the rule
+as a whole. Since the repository has no rulesets today, the migration is a clean one.
+
+Caveat worth verifying on the first run: the merge must be attributed to the bypassing app
+for the exemption to apply. Arm auto-merge with the app token (as the workflow already
+does with the PAT) and confirm on the next weekly run before relying on it.
+
+### Option C — Second approver (zero infrastructure, immediate)
+
+Add a `CODEOWNERS` entry for `public/sitemap/` naming another admin, or simply ask one of
+`jlaasonen` / `fsimonjetz` / `ejimsan` / `yCobanoglu` to approve each weekly PR. Nothing to
+build, but it keeps a human in the loop forever and will stall again whenever that person
+is away.
+
+### Option D — Stop versioning generated sitemaps (structural fix)
+
+Generate the sitemaps during the Docker build in `main.yml` and ship them in the image
+rather than committing them to `master`. The weekly PR, the bot identity and the bypass all
+become unnecessary. This is the cleanest long-term answer but changes the deployment story
+and needs its own design discussion.
+
+## Recommendation
+
+Adopt **Option A** now: it restores the reporter's ability to merge, removes a human PAT
+from CI, and requires no change to master branch protection at all. Layer on **Option B**
+afterwards if a weekly approving click is still considered too much friction. Keep
+**Option D** on the roadmap as the real elimination of the problem class.
+
+To clear the current backlog: have another admin approve **#778**, and close **#775** as
+superseded — both branches rewrite the same nine `public/sitemap/*.xml.gz` files, so
+merging one makes the other conflict, and #778 carries the fresher data.
+
+## Pre-existing issues found
+
+None of these affect correctness of the application, and no code was changed for them
+pending user approval:
+
+1. **65 stale `autoupdate-sitemap-*` branches on `origin`.** `deleteBranchOnMerge` is
+   `false` on the repository, and the workflow's `delete-branch: true` only removes the
+   branch when the _action_ closes the PR, not when GitHub merges it. Fix: enable
+   "Automatically delete head branches" in repository settings and prune the existing
+   branches.
+2. **Outdated action pins.** `peter-evans/create-pull-request@v5` (latest v8.1.1). Worth
+   bumping alongside the token change.
+3. **No `permissions:` block in `update-sitemaps.yml`.** `main.yml` correctly declares
+   `permissions: contents: read`; the sitemap workflow inherits the repository default and
+   should be explicit.
+
+## Change made
+
+Option A is implemented in `.github/workflows/update-sitemaps.yml`:
+
+- `actions/create-github-app-token@v3` mints a short-lived installation token; the
+  `SITEMAP_AUTOUPDATE` PAT is gone from the workflow.
+- A new "Resolve automation app identity" step derives the bot login and its
+  `users.noreply.github.com` address from the app slug, so the sitemap commits are
+  attributed to the bot rather than to `Ilya Khait <ilya.khait@lmu.de>`.
+- The hand-rolled `git config` / `git add` / `git commit` / `git diff --cached` step was
+  removed. `create-pull-request` performs the commit itself via `add-paths: public/sitemap`
+  plus the `author` / `committer` inputs, which is the documented usage and preserves the
+  previous behaviour of staging only `public/sitemap`. The action already no-ops when there
+  is nothing to commit, so the `commit-needed` output it replaced is redundant — the
+  auto-merge step's existing `pull-request-number != ''` guard still covers that case.
+- `peter-evans/create-pull-request` bumped v5 -> v8 (v5 predates the Node 20 runner
+  requirement). Every input used here — `token`, `add-paths`, `commit-message`, `committer`,
+  `author`, `title`, `body`, `base`, `branch`, `delete-branch` — is stable across those
+  versions.
+- Added an explicit `permissions: contents: read` block, matching `main.yml`.
+
+The workflow will fail until the two new secrets exist. Setup steps are in
+`TASK-sitemap-automerge-setup.md`.
+
+### Not done, and why
+
+- **Creating the GitHub App, adding secrets, changing repository settings, creating
+  rulesets** — the only credential available in the container is a scoped installation
+  token. It cannot even _read_ branch protection (`Resource not accessible by integration`
+  on `/branches/master/protection` and on `branchProtectionRules`), let alone administer
+  the org. Written up for the user instead.
+- **Approving #778** — the container token belongs to `khoidt`, the author of both stuck
+  PRs. This is the exact self-approval prohibition that caused the bug.
+- **Closing #775 and deleting the 65 stale branches** — destructive, outward-facing
+  operations on objects created by someone else. Left for explicit confirmation.
+
+## Gate status
+
+- `yarn lint` — passes, no errors.
+- `yarn tsc` — passes, no errors.
+- `yarn test --watchAll=false` — passes, exit code 0:
+
+  ```text
+  Test Suites: 405 passed, 405 total
+  Tests:       2 skipped, 3863 passed, 3865 total
+  Snapshots:   50 passed, 50 total
+  Time:        490.67 s
+  ```
+
+- Console-clean gate — met. Zero occurrences of `console.error`, `console.warn`,
+  `console.log`, `Warning:`, `not wrapped in act`, `UnhandledPromiseRejection` or
+  deprecation notices across the whole run.
+- Workflow YAML validated with `js-yaml`: parses, `permissions` block present, all ten
+  steps resolve in order.
+- Markdownlint warnings raised by the IDE against the task documents created here (table
+  column alignment, an unlabelled code fence, missing blank lines around a fence) were
+  fixed.
+
+### Pre-existing issue noted, not changed
+
+The 2 skipped tests are `xit('Renders transliteration field')` and
+`xit('Renders notes field')` in `src/fragmentarium/ui/edition/Edition.test.tsx:49-53`. They
+predate this task and are unrelated to it. Re-enabling them is not a safe drive-by change —
+they may have been disabled for a reason, and the project rule is that tests are never
+enabled, skipped or removed without explicit confirmation. Flagged for a separate decision.
+
+Only a CI workflow YAML file was changed; no file under `src/` was touched, so the suite is
+a regression check on unchanged code rather than coverage of the change itself. The change
+itself is only verifiable by running the workflow (step 5 of the setup document).

--- a/TASK-sitemap-automerge-setup.md
+++ b/TASK-sitemap-automerge-setup.md
@@ -1,0 +1,140 @@
+# Sitemap automation — setup steps for a repository / organisation admin
+
+The workflow change is already committed to `.github/workflows/update-sitemaps.yml` in this
+branch. It will **fail on its first run until steps 1–3 below are done**, because it now
+expects two new secrets. Everything in this file needs GitHub UI or admin-token access that
+is not available from inside the dev container, so it has to be done by you.
+
+Background and evidence for _why_ this is needed: `TASK-sitemap-automerge-log.md`.
+
+---
+
+## Step 1 — Create the automation GitHub App
+
+1. Go to <https://github.com/organizations/ElectronicBabylonianLiterature/settings/apps>
+   and click **New GitHub App**. Creating it under the _organisation_ (not your personal
+   account) matters — it keeps the automation alive if your account ever changes hands.
+2. Fill in:
+   - **GitHub App name**: `eBL Automation`
+     (this becomes the bot login `ebl-automation[bot]`; if the name is taken, pick another
+     and note the resulting slug — the workflow reads it automatically, so nothing to edit)
+   - **Homepage URL**: `https://github.com/ElectronicBabylonianLiterature/ebl-frontend`
+   - **Webhook**: untick **Active**. The app is only used to mint tokens.
+3. Under **Repository permissions**, set exactly these two and leave everything else at
+   _No access_:
+   - **Contents**: Read and write
+   - **Pull requests**: Read and write
+4. Under **Where can this GitHub App be installed?** choose **Only on this account**.
+5. Click **Create GitHub App**.
+
+## Step 2 — Install it and capture the credentials
+
+1. On the app's page, note the **App ID** shown near the top.
+2. Scroll to **Private keys** → **Generate a private key**. A `.pem` file downloads. This
+   is the only copy — GitHub will not show it again.
+3. In the left sidebar choose **Install App** → install it on the
+   `ElectronicBabylonianLiterature` organisation → **Only select repositories** →
+   select `ebl-frontend`.
+
+## Step 3 — Add the repository secrets
+
+Go to **Settings → Secrets and variables → Actions → New repository secret** on
+`ebl-frontend` and add both:
+
+| Secret name                  | Value                                                                                                                                 |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `EBL_AUTOMATION_APP_ID`      | the numeric App ID from step 2.1                                                                                                      |
+| `EBL_AUTOMATION_PRIVATE_KEY` | the **entire** contents of the `.pem` file, including the `-----BEGIN RSA PRIVATE KEY-----` and `-----END RSA PRIVATE KEY-----` lines |
+
+Paste the private key exactly as-is, newlines included. A single missing line break is the
+most common cause of a "failed to generate token" error on the first run.
+
+## Step 4 — Retire the old PAT
+
+Once step 5 confirms a green run, delete the now-unused `SITEMAP_AUTOUPDATE` repository
+secret, and revoke the underlying personal access token at
+<https://github.com/settings/tokens>. Leaving a long-lived admin PAT in the repository is
+the security half of this problem.
+
+## Step 5 — Verify
+
+Actions → **Update Sitemap** → **Run workflow** (it has `workflow_dispatch`).
+
+Expected result: a pull request titled _Automated sitemap update_ authored by
+**`ebl-automation[bot]`**, not by you, with auto-merge armed. You can now click **Approve**
+on it — which was impossible before, because you cannot approve your own pull request. Once
+approved, the armed auto-merge squashes it in with no further action.
+
+If the sitemaps happen to be unchanged, no PR is created and the run is still a success.
+
+---
+
+## Optional — fully unattended merging
+
+Steps 1–5 leave one approving click per week. To remove that too, master's protection has
+to gain a bypass for the app. **Classic branch protection cannot express this** — its
+bypass list only grants the right to push directly to `master`, which would skip CI on
+those commits entirely. Rulesets can, so this means migrating.
+
+The repository currently has **no rulesets at all**, so the migration is clean:
+
+1. **Settings → Rules → Rulesets → New branch ruleset.**
+2. Name it `master protection`, set **Enforcement status: Active**, and under **Target
+   branches** add **Include default branch**.
+3. Recreate the rules that classic protection enforces today. Based on the observed
+   behaviour of the blocked PRs, that is:
+   - **Require a pull request before merging** → _Required approvals: 1_
+   - **Require status checks to pass** → add the contexts currently required
+     (`test`, `Analyze (javascript)`, `CodeQL`, `GitGuardian Security Checks`,
+     `qlty check`, `qlty coverage`, `qlty coverage diff` — copy the exact list from the
+     classic rule before you disable it)
+   - **Block force pushes**
+4. Under **Bypass list** → **Add bypass** → **Apps** → select **eBL Automation**, mode
+   **Always**.
+5. Only after the ruleset is Active and verified, disable the classic branch protection
+   rule for `master` (Settings → Branches). Running both at once is safe but confusing —
+   GitHub applies the union of them, so the strictest wins.
+
+Human pull requests keep needing a review and green checks. The bot's PR merges itself.
+
+**Verify this one on a real run rather than assuming it.** The bypass applies to the actor
+performing the merge, and here that is the app arming auto-merge. It should work, but
+confirm the next weekly run actually merges before you rely on it being unattended.
+
+---
+
+## Housekeeping (independent of the above)
+
+1. **Stop the branch pile-up.** Settings → General → tick **Automatically delete head
+   branches**. `delete-branch: true` in the workflow only fires when the _action_ closes a
+   PR, not when GitHub merges it, which is why 65 `autoupdate-sitemap-*` branches are still
+   on the remote.
+2. **Prune the existing 65 branches.** After enabling the setting above, they can be
+   deleted in bulk. I have deliberately not done this — it is a destructive remote
+   operation on branches I did not create. Say the word and I will script it, or run:
+
+   ```bash
+   git ls-remote origin 'refs/heads/autoupdate-sitemap*' \
+     | awk '{print $2}' | sed 's|refs/heads/||' \
+     | xargs -n1 -I{} git push origin --delete {}
+   ```
+
+   Check the list before piping it to `xargs`.
+
+## Clearing the current backlog
+
+- **#778** (2026-08-02) — ask another admin (`jlaasonen`, `fsimonjetz`, `ejimsan`,
+  `yCobanoglu`) to approve. Auto-merge is already armed and every check is green, so the
+  approval alone merges it.
+- **#775** (2026-07-26) — close as superseded. Both branches rewrite the same nine
+  `public/sitemap/*.xml.gz` files, so merging one guarantees a binary conflict in the other,
+  and #778 carries the fresher data.
+
+I cannot do either myself: approving is blocked because the token available to me belongs
+to `khoidt`, who authored both PRs, and closing someone's PR is not a call I should make
+unprompted.
+
+## Reminder
+
+Delete `TASK-sitemap-automerge-todo.md`, `TASK-sitemap-automerge-log.md` and this file
+before the pull request carrying the workflow change is merged.

--- a/TASK-sitemap-automerge-todo.md
+++ b/TASK-sitemap-automerge-todo.md
@@ -1,0 +1,53 @@
+# TASK-sitemap-automerge — TODO
+
+Investigate why automated sitemap update PRs stopped merging after master branch
+protection was introduced, and propose a solution that keeps master protection in place.
+
+## Investigation
+
+- [x] Locate the automation that produces the updates (`.github/workflows/update-sitemaps.yml`)
+- [x] Identify which PRs are stuck and since when
+- [x] Determine the identity that authors the automated PRs
+- [x] Confirm whether CI / required status checks pass on the stuck PRs
+- [x] Determine the exact merge blocker via the GitHub API (`mergeStateStatus`, `reviewDecision`)
+- [x] Confirm the reporter's repository permission level and whether admin bypass is available
+- [x] Check for repository / organisation rulesets vs classic branch protection
+- [x] Check whether the stuck PRs conflict with each other
+
+## Deliverable
+
+- [x] Document root cause and options in `TASK-sitemap-automerge-log.md`
+- [x] Recommend a solution that preserves master branch protection
+
+## Implementation (done in this branch)
+
+- [x] Implement Option A in `.github/workflows/update-sitemaps.yml`:
+  - [x] Mint a short-lived installation token with `actions/create-github-app-token@v3`
+  - [x] Resolve the bot login and no-reply email so commits are attributed to the app
+  - [x] Replace the PAT with the app token in both the create-PR and auto-merge steps
+  - [x] Drop the hand-rolled `git config` / `git commit` / `git diff --cached` step in
+        favour of the action's own `add-paths` / `author` / `committer` inputs
+- [x] Housekeeping: bump `peter-evans/create-pull-request` v5 -> v8
+- [x] Housekeeping: add an explicit `permissions: contents: read` block
+- [x] Validate the workflow YAML parses and the step graph is intact
+- [x] Write `TASK-sitemap-automerge-setup.md` covering everything needing admin access
+
+## Requires the user (no container access — see TASK-sitemap-automerge-setup.md)
+
+- [ ] Create the `eBL Automation` GitHub App and install it on `ebl-frontend`
+- [ ] Add `EBL_AUTOMATION_APP_ID` and `EBL_AUTOMATION_PRIVATE_KEY` repository secrets
+- [ ] Verify with a manual `workflow_dispatch` run, then delete the `SITEMAP_AUTOUPDATE`
+      secret and revoke the underlying PAT
+- [ ] Optional Option B: migrate master to a ruleset with the app as a bypass actor
+- [ ] Unblock the backlog: have another admin approve #778, close #775 as superseded
+- [ ] Housekeeping: enable "Automatically delete head branches"; prune the 65 stale
+      `autoupdate-sitemap-*` branches
+
+## Gates
+
+- [x] `yarn lint` — clean
+- [x] `yarn tsc` — clean
+- [x] `yarn test --watchAll=false` — 405 suites / 3863 tests passed, exit 0
+- [x] Console-clean run — zero console output of any kind
+- [ ] Remove this file, `TASK-sitemap-automerge-log.md` and
+      `TASK-sitemap-automerge-setup.md` before the PR is merged.


### PR DESCRIPTION
## Problem

The weekly **Automated sitemap update** pull requests have not merged since master branch protection was tightened. The last one through was #772 on 2026-07-19; #775 and #778 are still open.

The cause is identity, not CI. `update-sitemaps.yml` opens the PR with `secrets.SITEMAP_AUTOUPDATE`, a personal access token belonging to `khoidt`, so the PR author is a human being. GitHub forbids self-approval, and admin enforcement removes the bypass, so the one person who would merge these is the one person who cannot. Auto-merge is already armed on both stuck PRs, waiting for a review that can never arrive.

Confirmed via the API on both:

```text
mergeStateStatus: BLOCKED      reviewDecision: REVIEW_REQUIRED
mergeable: true                viewerDidAuthor: true
```

Every required check is green on both — `test`, CodeQL, GitGuardian, and all three `qlty` contexts.

## Fix

Mint a short-lived GitHub App installation token instead of using a human's PAT. The pull request and the sitemap commits are then attributed to the app, so any maintainer — including the previous author — can approve and merge.

**Master branch protection is unchanged.**

Switching to the default `GITHUB_TOKEN` looks like the obvious fix and is a trap: PRs it opens deliberately do not trigger workflows, so the required status checks would never run and the PRs would be permanently blocked rather than merely needing a click.

## Changes

- `actions/create-github-app-token@v3` mints the token; the PAT is gone from the workflow
- A new step resolves the bot login and its no-reply address from the app slug, so commits stop being attributed to `Ilya Khait <ilya.khait@lmu.de>`. The slug is read at runtime — renaming the App needs no edit here
- The hand-rolled `git config` / `git add` / `git commit` / `git diff --cached` step is replaced by the action's own `add-paths: public/sitemap` plus `author` / `committer`, preserving the previous staging behaviour. The action already no-ops when there is nothing to commit, and the auto-merge step's existing `pull-request-number != ''` guard covers that case
- `peter-evans/create-pull-request` v5 → v8 (v5 predates the Node 20 runner requirement); every input used is stable across those versions
- Explicit `permissions: contents: read`, matching `main.yml`

## ⚠️ Action required before this works

**The workflow will fail on its first run until two new secrets exist.** `TASK-sitemap-automerge-setup.md` has the click-by-click steps: create the org-owned GitHub App with Contents + Pull requests write, install it on this repo, add `EBL_AUTOMATION_APP_ID` and `EBL_AUTOMATION_PRIVATE_KEY`, verify with a manual `workflow_dispatch` run, then delete the `SITEMAP_AUTOUPDATE` secret and revoke the underlying PAT.

That document also covers the optional ruleset migration for fully unattended merging, which classic branch protection cannot express.

## Verification

- `yarn lint` — clean
- `yarn tsc` — clean
- `yarn test --watchAll=false` — 405 suites, 3863 passed, 2 pre-existing skips, exit 0
- Console-clean: zero `console.error` / `console.warn` / `Warning:` / act / unhandled-rejection output across the run
- Workflow YAML validated with `js-yaml`

No file under `src/` is touched, so the suite is a regression check rather than coverage of this change; the change itself is only verifiable by running the workflow, which is step 5 of the setup doc.

## Backlog, not done here

- **#778** needs an approval from another admin — auto-merge is armed and all checks are green, so approval alone merges it
- **#775** should be closed as superseded; both branches rewrite the same nine `public/sitemap/*.xml.gz` files, so merging one guarantees a binary conflict in the other, and #778 has fresher data
- 65 stale `autoupdate-sitemap-*` branches remain because **Automatically delete head branches** is off; `delete-branch: true` only fires when the action closes a PR, not when GitHub merges it

## Before merging

Delete `TASK-sitemap-automerge-todo.md`, `TASK-sitemap-automerge-log.md` and `TASK-sitemap-automerge-setup.md` — but keep the setup file's content somewhere first, since the secrets still need creating.